### PR TITLE
[25, 5] fix wave errors on header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -99,7 +99,7 @@ aria-label="Official website of the United States government"
         <em class="usa-logo__text"
           ><a href="/" title="challenge.gov">
           <span class="site-title--long">
-            <img width="300" class="usa-header__logo-img margin-left-4 desktop:margin-left-2 desktop:margin-bottom-2" src="<%= image_path("challenge-logo.svg") %>" alt="" />
+            <img width="300" class="usa-header__logo-img margin-left-4 desktop:margin-left-2 desktop:margin-bottom-2" src="<%= image_path("challenge-logo.svg") %>" alt="challenge logo" />
           </span>  
           </a></em
         >
@@ -136,10 +136,10 @@ aria-label="Official website of the United States government"
       <section class="display-none desktop:display-flex">
         <section aria-label="Search component">
           <form class="usa-search usa-search--small" role="search">
-            <label class="usa-sr-only" for="search-field">Search</label>
+            <label class="usa-sr-only" for="search-field-desktop">Search</label>
             <input
               class="usa-input"
-              id="search-field"
+              id="search-field-desktop"
               type="search"
               name="search"
               style="width: 140px"


### PR DESCRIPTION
This cleans up some wave errors on the header. 

Including a screenshot of the clean wave report as needed for tickets 25 (header) and 5 (government banner):

![Screen Shot 2024-09-25 at 3 48 38 PM](https://github.com/user-attachments/assets/fb63fd42-3eb2-4f57-a9ca-6a487f3600cf)
