### PR TITLE
Evaluation Form layout and app container shakeup

### DIFF
--- a/app/views/dashboard/_dashboard.html.erb
+++ b/app/views/dashboard/_dashboard.html.erb
@@ -1,4 +1,4 @@
-<main class="grid-container flex-justify-center width-full padding-bottom-4">
+<div class="flex-justify-center width-full padding-bottom-4">
     <h1><%= dashboard_title[role] %></h1>
     <% dashboard_cards_by_role[role].each_slice(2) do |card1, card2| %>
         <div class="grid-row grid-gap-2">
@@ -6,4 +6,4 @@
             <%= render partial: "dashboard_card", locals: { card: card2 } if card2 %>
         </div>
     <% end %>    
-</main>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,9 +1,7 @@
-<main role="main">
-  <div class="usa-card__container col-md-6">
-      <% if logged_in? %>
-        <%= render partial: "dashboard", locals: { role: current_user.role.to_sym } %>
-      <% else %>
-        <h1 class="usa-card__body">Logged Out Dashboard Index</h1>
-      <% end %>
-  </div>
-</main>
+<div class="col-md-6">
+    <% if logged_in? %>
+      <%= render partial: "dashboard", locals: { role: current_user.role.to_sym } %>
+    <% else %>
+      <h1 class="usa-card__body">Logged Out Dashboard Index</h1>
+    <% end %>
+</div>

--- a/app/views/evaluation_forms/_form.html.erb
+++ b/app/views/evaluation_forms/_form.html.erb
@@ -11,7 +11,6 @@
     </div>
   <% end %>
 
-  <h3 class="site-preview-heading">Default</h3>
   <ol class="usa-process-list">
     <li class="usa-process-list__item">
       <h4 class="usa-process-list__heading">Evaluation Information</h4>

--- a/app/views/evaluation_forms/_form.html.erb
+++ b/app/views/evaluation_forms/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: evaluation_form) do |form| %>
   <% if evaluation_form.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(evaluation_form.errors.count, "error") %> prohibited this evaluation_form from being saved:</h2>
+      <h2><%= pluralize(evaluation_form.errors.count, "error") %> prohibited this evaluation form from being saved:</h2>
 
       <ul>
         <% evaluation_form.errors.each do |error| %>
@@ -11,40 +11,64 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.label :title, style: "display: block" %>
-    <%= form.text_field :title %>
-  </div>
+  <h3 class="site-preview-heading">Default</h3>
+  <ol class="usa-process-list">
+    <li class="usa-process-list__item">
+      <h4 class="usa-process-list__heading">Evaluation Information</h4>
+      <p class="margin-top-05">
+        Create an evaluation form title, assign it to your challenge and
+        provide instructions that will be shared with your evaluators. 
+      </p>
+      <div>
+        <%= form.label :title, style: "display: block" %>
+        <%= form.text_field :title %>
+      </div>
 
-  <div>
-    <%= form.label :instructions, style: "display: block" %>
-    <%= form.text_field :instructions %>
-  </div>
+      <div>
+        <%= form.label :challenge_phase, style: "display: block" %>
+        <%= form.number_field :challenge_phase %>
+      </div>
 
-  <div>
-    <%= form.label :challenge_phase, style: "display: block" %>
-    <%= form.number_field :challenge_phase %>
-  </div>
+      <div>
+        <%= form.label :challenge_id, style: "display: block" %>
+        <%= form.text_field :challenge_id %>
+      </div>
 
-  <div>
-    <%= form.label :comments_required, style: "display: block" %>
-    <%= form.check_box :comments_required %>
-  </div>
+      <div>
+        <%= form.label :instructions, style: "display: block" %>
+        <%= form.text_field :instructions %>
+      </div>
+    </li>
+    <li class="usa-process-list__item">
+      <h4 class="usa-process-list__heading">Evaluation Criteria</h4>
+      <p>
+        Create your evaluation criteria and scoring options.
+      </p>
+      <div>
+        <%= form.label :comments_required, style: "display: block" %>
+        <%= form.check_box :comments_required %>
+      </div>
 
-  <div>
-    <%= form.label :weighted_scoring, style: "display: block" %>
-    <%= form.check_box :weighted_scoring %>
-  </div>
+      <div>
+        <%= form.label :weighted_scoring, style: "display: block" %>
+        <%= form.check_box :weighted_scoring %>
+      </div>
+    </li>
+    <li class="usa-process-list__item">
+      <h4 class="usa-process-list__heading">Evaluation Period</h4>
+      <p>
+        Set the end date of your evaluation period.
+        Your evaluation start date is the end date of your challenge.
+      </p>
+      <div>
+        <%= form.label :closing_date, style: "display: block" %>
+        <%= form.date_field :closing_date %>
+      </div>
+    </li>
+  </ol>
 
-  <div>
-    <%= form.label :closing_date, style: "display: block" %>
-    <%= form.date_field :closing_date %>
-  </div>
 
-  <div>
-    <%= form.label :challenge_id, style: "display: block" %>
-    <%= form.text_field :challenge_id %>
-  </div>
+  
 
   <div>
     <%= form.submit %>

--- a/app/views/evaluation_forms/index.html.erb
+++ b/app/views/evaluation_forms/index.html.erb
@@ -1,27 +1,24 @@
-<div class="usa-card__body">
-  <h1>Evaluation Forms</h1>
-  <p class="text-normal">Manage existing evaluation forms and create new evaluation forms.</p>
+<h1>Evaluation Forms</h1>
+<p class="text-normal">Manage existing evaluation forms and create new evaluation forms.</p>
 
-  <p>
-    <%= link_to new_evaluation_form_path, class: "width-full tablet:width-auto" do %>
-      <button class="usa-button font-body-2xs text-no-wrap" style="background-color: #4d8055">
-        <%= image_tag(
-          "images/usa-icons/content_copy.svg",
-          class: "usa-icon icon-white",
-          alt: "evaluation forms"
-        )%>
-        Create New Evaluation Form
-      </button>
-    <% end %>
-  </p>
+<p>
+  <%= link_to new_evaluation_form_path, class: "width-full tablet:width-auto" do %>
+    <button class="usa-button font-body-2xs text-no-wrap" style="background-color: #4d8055">
+      <%= image_tag(
+        "images/usa-icons/content_copy.svg",
+        class: "usa-icon icon-white",
+        alt: "evaluation forms"
+      )%>
+      Create New Evaluation Form
+    </button>
+  <% end %>
+</p>
 
-  <% if @evaluation_forms.empty? %>
-    <div class="text-normal">
-      <p>You currently do not have any evaluation forms.<br/>
-      Please create an evaluation form for your challenge before it is published.</p>
-    </div>
-  <% else %>
-    <%= render partial: "table", locals: { evaluation_forms: @evaluation_forms } %>
-  <% end %>  
-
-</div>
+<% if @evaluation_forms.empty? %>
+  <div class="text-normal">
+    <p>You currently do not have any evaluation forms.<br/>
+    Please create an evaluation form for your challenge before it is published.</p>
+  </div>
+<% else %>
+  <%= render partial: "table", locals: { evaluation_forms: @evaluation_forms } %>
+<% end %>  

--- a/app/views/evaluation_forms/new.html.erb
+++ b/app/views/evaluation_forms/new.html.erb
@@ -1,6 +1,6 @@
-<% content_for :title, "New evaluation form" %>
+<% content_for :title, "Create Evaluation Form" %>
 
-<h1>New evaluation form</h1>
+<h1>Create Evaluation Form</h1>
 
 <%= render "form", evaluation_form: @evaluation_form %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,8 +28,10 @@
     <% end %>  
     <%= render "shared/flash" %>
 
-    <%= yield %>
-
+    <main class="grid-container">
+      <%= yield %>
+    </main>
+    
     <%= render "layouts/footer" %>
     <%= render "modals/renew_session" %>
     <%= javascript_include_tag 'uswds', async: true %>


### PR DESCRIPTION
This PR puts the step by step process list layout in place on the evaluation form builder. It also applies the uswds grid-container class, which had previously been used to control the width of the dashboard component, to the main app layout. This standardizes page width throughout the app and makes pre-existing pages (like the eval form list) match Figma better.  

Eval form builder layout: 
<img width="1383" alt="Screen Shot 2024-10-02 at 10 23 59 AM" src="https://github.com/user-attachments/assets/98789ea5-436c-47f8-bfb4-a15e0c81f820">

Eval form list, demonstrating new app container (notice that it's the same width as dashboard):
<img width="1389" alt="Screen Shot 2024-10-02 at 10 24 19 AM" src="https://github.com/user-attachments/assets/2e23fa33-e939-48e3-a044-ccfa20602595">

wave:
<img width="1375" alt="Screen Shot 2024-10-02 at 11 11 32 AM" src="https://github.com/user-attachments/assets/a0f38c75-2127-49f2-9960-1c9990be4e79">
