### PR TITLE
Eval Form Javascript Install / Character Count Implementation

### DIFF
--- a/app/javascript/evaluation_form.js
+++ b/app/javascript/evaluation_form.js
@@ -1,0 +1,5 @@
+document.addEventListener("DOMContentLoaded", function () {
+    document.getElementById("evaluation_form_instructions").addEventListener("input", (e ) => {
+        document.getElementById("character_counter").innerHTML = 3000 - e.target.value.length
+    })
+})    

--- a/app/views/evaluation_forms/_form.html.erb
+++ b/app/views/evaluation_forms/_form.html.erb
@@ -1,3 +1,6 @@
+<% content_for :head do %>
+  <%= javascript_include_tag('evaluation_form') %>
+<% end %>  
 <%= form_with(model: evaluation_form) do |form| %>
   <% if evaluation_form.errors.any? %>
     <div style="color: red">
@@ -35,8 +38,9 @@
 
       <div>
         <%= form.label :instructions, style: "display: block" %>
-        <%= form.text_field :instructions %>
+        <%= form.text_area :instructions, style: "height: 150px;" %>
       </div>
+      <span id="character_counter">3000</span> Characters Allowed
     </li>
     <li class="usa-process-list__item">
       <h4 class="usa-process-list__heading">Evaluation Criteria</h4>

--- a/app/views/evaluation_forms/_form.html.erb
+++ b/app/views/evaluation_forms/_form.html.erb
@@ -36,11 +36,14 @@
         <%= form.text_field :challenge_id %>
       </div>
 
-      <div>
-        <%= form.label :instructions, style: "display: block" %>
-        <%= form.text_area :instructions, style: "height: 150px;" %>
+      <div class="usa-character-count">
+        <div class="usa-form-group">
+          <%= form.label :instructions, class: "usa-label" %>
+          <%= form.text_area :instructions, class: "usa-textarea usa-character-count__field", maxlength: 3000, rows: "7" %>
+        </div>
+        <span id="with-hint-textarea-info" class="usa-character-count__message">You can enter up to 3000 characters</span>
       </div>
-      <span id="character_counter">3000</span> Characters Allowed
+
     </li>
     <li class="usa-process-list__item">
       <h4 class="usa-process-list__heading">Evaluation Criteria</h4>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,6 +19,8 @@
 
       <%= javascript_include_tag 'session_timeout' %>
     <% end %>
+
+      <%= content_for :head %>
   </head>
 
   <body>


### PR DESCRIPTION
This is a proposal for implementing user feedback on the evaluation form using vanilla JS (as opposed to the previously-discussed stimulus)

The javascript is conditionally inserted into the head of the document when the form is rendered. 

Validating character count for evaluation instructions has been implemented for demonstration purposes. 

I prefer this approach to active record validations on the server side (which was the main value add of using stimulus). Ticket #160 specifies that we want to validate each field one by one as it is unfocused which will be more straightforward to implement using this approach rather than bouncing the entire set of attrs off the server.

updated to use the uswds character count component. 