### PR TITLE
Eval Form Datepicker Fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
   rspec:
     executor:
       name: test_executor
-    
+
     environment:
       PHOENIX_URI: http://localhost:4000
 
@@ -122,6 +122,9 @@ jobs:
   report_coverage:
     executor:
       name: test_executor
+
+    environment:
+      - CC_TEST_REPORTER_ID: "a561562e78b6f0b3e346d4811eef2b020f977cd089bf459f102f6229dd100703"
 
     steps:
       - restore_cache:

--- a/app/views/evaluation_forms/_form.html.erb
+++ b/app/views/evaluation_forms/_form.html.erb
@@ -23,7 +23,7 @@
       <label class="usa-label" for="challenge-combo">Select a challenge</label>
       <div class="usa-hint">Choose the challenge this form will evaluate.</div>
       <div class="usa-combo-box" data-default-value="<%= combo_box_default_value %>">
-        <select class="usa-select" name="challenge-combo" data-action="evaluation-form#handleChallengeSelect">
+        <select class="usa-select" id="challenge-combo" title="challenge-combo" data-action="evaluation-form#handleChallengeSelect">
           <% current_user.challenge_manager_challenges.each do |challenge| %>
             <% challenge.phases.each do |phase| %>
               <option value="<%= "#{challenge.id}.#{phase.id}.#{phase.end_date.strftime("%m/%d/%Y")}" %>"><%= challenge_phase_title(challenge, phase) %></option>


### PR DESCRIPTION
The datepicker for closing date on the eval form was broken because the combo box element was throwing a javascript error which caused all of the USWDS javascript to crash. 

Fixed this by switching the name attribute of the combo box select to be an id attribute. This wouldn't ordinarily be required in HTML but is needed for how USWDS javascript strips down and rebuilds the element on initialization. 

This further necessitated the introduction of a title attribute which satisfies the wave tool. 

