### PR TITLE
[52] Dashboard fixup

### DIFF
--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -8,7 +8,7 @@ module NavigationHelper
       image_tag(
         "images/usa-icons/#{image_path}.svg",
         class: "usa-icon--size-4 desktop:usa-icon--size-3 icon-white desktop:margin-right-1",
-        alt:
+        alt: ""
       ) +
         tag.span(button_label, class: "display-none desktop:display-block") +
         tag.span(button_label, class: "desktop:display-none", style: "font-size: 0.7rem")

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module NavigationHelper
-  def utility_menu_link(image_path, href, alt, button_label)
+  def utility_menu_link(image_path, href, _alt, button_label)
     link_to(href,
             class: "display-flex flex-align-center flex-column desktop:flex-row " \
                    "margin-x-1 desktop:margin-x-3 text-white text-no-wrap") do

--- a/app/views/dashboard/_dashboard_card.html.erb
+++ b/app/views/dashboard/_dashboard_card.html.erb
@@ -5,7 +5,7 @@
         <%= image_tag(
             "images/usa-icons/#{card[:image_path]}.svg",
             class: "usa-icon--size-7 icon-white margin-x-2",
-            alt: card[:alt]
+            alt: ""
         )%>
         <div class="margin-right-2" >
             <h2><%= card[:title] %></h2>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -99,7 +99,7 @@ aria-label="Official website of the United States government"
         <em class="usa-logo__text"
           ><a href="/" title="challenge.gov">
           <span class="site-title--long">
-            <img width="300" class="usa-header__logo-img margin-left-4 desktop:margin-left-2 desktop:margin-bottom-2" src="<%= image_path("challenge-logo.svg") %>" alt="challenge logo" />
+            <img width="300" class="usa-header__logo-img desktop:margin-bottom-2" src="<%= image_path("challenge-logo.svg") %>" alt="challenge logo" />
           </span>  
           </a></em
         >


### PR DESCRIPTION
This PR addresses the accessibility failures found in ticket 52. 

Icons have been made decorative with empty strings for alt attributes.

The challenge.gov logo in the header has been changed to shrink on very small screen sizes instead of truncating.  