### PR TITLE
fix the migrations on challenge-dev

### DIFF
--- a/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb
+++ b/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb
@@ -1,5 +1,6 @@
 class ChangeNullValuesOnEvaluationForms < ActiveRecord::Migration[7.2]
   def change
+    ActiveRecord::Base.connection.truncate_tables(EvaluationForm.table_name)
     change_column_null :evaluation_forms, :title, false
     change_column_null :evaluation_forms, :instructions, false
     change_column_null :evaluation_forms, :challenge_phase, false


### PR DESCRIPTION
The migration is failing on the staging machine with the following error:
```
15:21:38.517: [APP/PROC/WEB.0] rake aborted!
15:21:38.517: [APP/PROC/WEB.0] StandardError: An error has occurred, this and all later migrations canceled: (StandardError)
15:21:38.517: [APP/PROC/WEB.0] PG::NotNullViolation: ERROR:  column "challenge_id" of relation "evaluation_forms" contains null values
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:56:in `exec'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:56:in `block (2 levels) in raw_execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:1004:in `block in with_raw_connection'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activesupport-7.2.1.1/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:976:in `with_raw_connection'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:55:in `block in raw_execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activesupport-7.2.1.1/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/abstract_adapter.rb:1119:in `log'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:54:in `raw_execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/abstract/database_statements.rb:538:in `internal_execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/abstract/database_statements.rb:137:in `execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/abstract/query_cache.rb:27:in `execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/postgresql/database_statements.rb:48:in `execute'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/connection_adapters/postgresql/schema_statements.rb:459:in `change_column_null'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/migration/default_strategy.rb:10:in `method_missing'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/migration.rb:1059:in `block in method_missing'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/migration.rb:1025:in `block in say_with_time'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/migration.rb:1025:in `say_with_time'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/deps/2/vendor_bundle/ruby/3.2.0/gems/activerecord-7.2.1.1/lib/active_record/migration.rb:1048:in `method_missing'
15:21:38.518: [APP/PROC/WEB.0] /home/vcap/app/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb:7:in `change'
```
There is a null value present in the table and the migration can not proceed. I believe this PR will allow the migration to complete and the other migrations to run.