### PR TITLE
Fix broken migration staging

### DIFF
--- a/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb
+++ b/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb
@@ -1,5 +1,6 @@
 class ChangeNullValuesOnEvaluationForms < ActiveRecord::Migration[7.2]
   def change
+    ActiveRecord::Base.connection.truncate_tables(EvaluationForm.table_name)
     change_column_null :evaluation_forms, :title, false
     change_column_null :evaluation_forms, :instructions, false
     change_column_null :evaluation_forms, :challenge_phase, false

--- a/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb
+++ b/db/migrate/20241001143033_change_null_values_on_evaluation_forms.rb
@@ -1,6 +1,8 @@
 class ChangeNullValuesOnEvaluationForms < ActiveRecord::Migration[7.2]
   def change
-    ActiveRecord::Base.connection.truncate_tables(EvaluationForm.table_name)
+    # reset both tables due to foreign_key constraint
+    execute('DELETE FROM evaluation_criteria;')
+    execute('DELETE FROM evaluation_forms;')
     change_column_null :evaluation_forms, :title, false
     change_column_null :evaluation_forms, :instructions, false
     change_column_null :evaluation_forms, :challenge_phase, false

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -652,7 +652,7 @@ CREATE TABLE public.oban_jobs (
     attempted_by text[],
     discarded_at timestamp without time zone,
     priority integer DEFAULT 0 NOT NULL,
-    tags character varying(255)[] DEFAULT ARRAY[]::character varying[],
+    tags text[] DEFAULT ARRAY[]::text[],
     meta jsonb DEFAULT '{}'::jsonb,
     cancelled_at timestamp without time zone,
     CONSTRAINT attempt_range CHECK (((attempt >= 0) AND (attempt <= max_attempts))),


### PR DESCRIPTION
The last try failed because `evaluation_criteria` has a foreign_key constraint so we have to delete the table data instead of truncate.