### PR TITLE
fail cloud_start.sh script on any errors

### DIFF
--- a/cloud_start.sh
+++ b/cloud_start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 echo "------ Starting APP ------ Instance $CF_INSTANCE_INDEX -----"
 echo "------ Booting Instance ------ Instance $CF_INSTANCE_INDEX -----"
 if [ "$CF_INSTANCE_INDEX" == "0" ]; then


### PR DESCRIPTION
This change should cause the script to exit when any of the commands fails. The goal is to fail on line 8:
```
bundle exec rake cf:on_first_instance db:migrate
```