### PR TITLE
[245] Invited Evaluators User Setup

### DIFF
--- a/app/controllers/manage_evaluators_controller.rb
+++ b/app/controllers/manage_evaluators_controller.rb
@@ -78,13 +78,15 @@ class ManageEvaluatorsController < ApplicationController
 
   # Create action helpers
   def process_evaluator_invitation(email)
-    existing_invitation = @challenge.evaluator_invitations.find_by(email:, phase: @phase)
-    user = User.find_by(email:)
+    user = User.find_by(email: email)
+    existing_invitation = @challenge.evaluator_invitations.find_by(email: email, phase: @phase)
 
-    if existing_invitation
+    if user
+      result = add_user_as_evaluator(user)
+      existing_invitation&.destroy if result[:success]
+      result
+    elsif existing_invitation
       resend_invitation(existing_invitation)
-    elsif user && valid_evaluator_role?(user)
-      add_user_as_evaluator(user)
     else
       create_new_invitation(email)
     end
@@ -105,8 +107,11 @@ class ManageEvaluatorsController < ApplicationController
   end
 
   def add_user_as_evaluator(user)
-    cpe = ChallengePhasesEvaluator.find_or_create_by(challenge: @challenge, phase: @phase, user:)
+    cpe = ChallengePhasesEvaluator.find_or_create_by(challenge: @challenge, phase: @phase, user: user)
+    invitation = @challenge.evaluator_invitations.find_by(email: user.email, phase: @phase)
+
     if cpe.persisted?
+      invitation&.destroy
       { success: true, message: "#{user.email} has been added as an evaluator for this phase." }
     else
       { success: false, message: "Failed to add #{user.email} as an evaluator." }

--- a/app/controllers/manage_evaluators_controller.rb
+++ b/app/controllers/manage_evaluators_controller.rb
@@ -179,6 +179,7 @@ class ManageEvaluatorsController < ApplicationController
 
   def render_json_response(result)
     if result[:success]
+      flash[:notice] = result[:message]
       render json: { success: true, message: result[:message] }
     else
       render json: { success: false, message: result[:message] }, status: :unprocessable_entity

--- a/app/controllers/manage_evaluators_controller.rb
+++ b/app/controllers/manage_evaluators_controller.rb
@@ -6,8 +6,6 @@ class ManageEvaluatorsController < ApplicationController
   before_action :set_challenge
   before_action :set_phases, only: [:index]
 
-  VALID_EVALUATOR_ROLES = %w[evaluator solver challenge_manager].freeze
-
   def index
     if @phases.empty?
       handle_empty_phases
@@ -18,12 +16,12 @@ class ManageEvaluatorsController < ApplicationController
 
   def create
     @phase = @challenge.phases.find(evaluator_invitation_params[:phase_id])
-    result = process_evaluator_invitation(evaluator_invitation_params[:email])
+    user = User.find_by(email: evaluator_invitation_params[:email])
 
-    if result[:success]
-      handle_successful_creation(result)
+    if existing_evaluator?(user)
+      handle_existing_evaluator(user)
     else
-      handle_failed_creation
+      process_new_evaluator
     end
   end
 
@@ -45,6 +43,10 @@ class ManageEvaluatorsController < ApplicationController
     @phases = @challenge.phases.order(:start_date)
   end
 
+  def existing_evaluator?(user)
+    user && ChallengePhasesEvaluator.exists?(challenge: @challenge, phase: @phase, user: user)
+  end
+
   def evaluator_invitation_params
     params.require(:evaluator_invitation).permit(
       :first_name, :last_name, :email, :challenge_id, :phase_id, :last_invite_sent
@@ -60,61 +62,44 @@ class ManageEvaluatorsController < ApplicationController
 
   def handle_existing_phases
     @phase = select_phase
-    @evaluator_invitations = fetch_evaluator_invitations
-    @existing_evaluators = fetch_existing_evaluators
+    fetch_evaluators_and_invitations
   end
 
   def select_phase
     params[:phase_id] ? @phases.find(params[:phase_id]) : @phases.first
   end
 
-  def fetch_evaluator_invitations
-    @phase.evaluator_invitations
-  end
-
-  def fetch_existing_evaluators
-    @phase.evaluators
+  def fetch_evaluators_and_invitations
+    @evaluator_invitations = @phase.evaluator_invitations
+    @existing_evaluators = @phase.evaluators
   end
 
   # Create action helpers
+  def process_new_evaluator
+    result = process_evaluator_invitation(evaluator_invitation_params[:email])
+    result[:success] ? handle_successful_creation(result) : handle_failed_creation(result[:message])
+  end
+
   def process_evaluator_invitation(email)
     user = User.find_by(email: email)
-    existing_invitation = @challenge.evaluator_invitations.find_by(email: email, phase: @phase)
-
     if user
-      result = add_user_as_evaluator(user)
-      existing_invitation&.destroy if result[:success]
-      result
-    elsif existing_invitation
-      resend_invitation(existing_invitation)
+      add_user_as_evaluator(user)
     else
-      create_new_invitation(email)
+      existing_invitation = @challenge.evaluator_invitations.find_by(email: email, phase: @phase)
+      existing_invitation ? resend_invitation(existing_invitation) : create_new_invitation(email)
     end
   end
 
-  # prevent duplicate evaluator invitations
-  def resend_invitation(invitation)
-    invitation.update(last_invite_sent: Time.current) # only update last_invite_sent for now
-    {
-      success: true,
-      message: "An invitation to this challenge has already been sent to " \
-               "#{invitation.email}. Invitation has been resent."
-    }
-  end
-
-  def valid_evaluator_role?(user)
-    VALID_EVALUATOR_ROLES.include?(user.role)
-  end
-
   def add_user_as_evaluator(user)
-    cpe = ChallengePhasesEvaluator.find_or_create_by(challenge: @challenge, phase: @phase, user: user)
-    invitation = @challenge.evaluator_invitations.find_by(email: user.email, phase: @phase)
-
-    if cpe.persisted?
-      invitation&.destroy
-      { success: true, message: "#{user.email} has been added as an evaluator for this phase." }
+    if User::VALID_EVALUATOR_ROLES.include?(user.role)
+      cpe = ChallengePhasesEvaluator.find_or_create_by(challenge: @challenge, phase: @phase, user: user)
+      if cpe.persisted?
+        { success: true, message: "#{user.email} has been added as an evaluator for this phase." }
+      else
+        { success: false, message: "Failed to add #{user.email} as an evaluator." }
+      end
     else
-      { success: false, message: "Failed to add #{user.email} as an evaluator." }
+      { success: false, message: "#{user.email} does not have a valid evaluator role." }
     end
   end
 
@@ -132,10 +117,25 @@ class ManageEvaluatorsController < ApplicationController
                 notice: result[:message]
   end
 
-  def handle_failed_creation
-    @evaluator_invitations = fetch_evaluator_invitations
-    @existing_evaluators = fetch_existing_evaluators
+  def handle_failed_creation(error_message)
+    flash.now[:alert] = error_message
+    fetch_evaluators_and_invitations
     render :index
+  end
+
+  # prevent duplicate evaluators or evauator invitations
+  def handle_existing_evaluator(user)
+    flash[:notice] = "#{user.email} has already been added as an evaluator for this phase."
+    redirect_to challenge_manage_evaluators_path(@challenge, phase_id: @phase.id)
+  end
+
+  def resend_invitation(invitation)
+    invitation.update(last_invite_sent: Time.current) # only update last_invite_sent for now
+    {
+      success: true,
+      message: "An invitation to this challenge has already been sent to " \
+               "#{invitation.email}. Invitation has been resent."
+    }
   end
 
   # Destroy action helpers
@@ -179,7 +179,6 @@ class ManageEvaluatorsController < ApplicationController
 
   def render_json_response(result)
     if result[:success]
-      flash[:notice] = result[:message]
       render json: { success: true, message: result[:message] }
     else
       render json: { success: false, message: result[:message] }, status: :unprocessable_entity

--- a/app/controllers/manage_evaluators_controller.rb
+++ b/app/controllers/manage_evaluators_controller.rb
@@ -123,7 +123,7 @@ class ManageEvaluatorsController < ApplicationController
     render :index
   end
 
-  # prevent duplicate evaluators or evauator invitations
+  # prevent duplicate evaluators or evaluator invitations
   def handle_existing_evaluator(user)
     flash[:notice] = "#{user.email} has already been added as an evaluator for this phase."
     redirect_to challenge_manage_evaluators_path(@challenge, phase_id: @phase.id)

--- a/app/helpers/manage_evaluators_helper.rb
+++ b/app/helpers/manage_evaluators_helper.rb
@@ -3,7 +3,7 @@
 module ManageEvaluatorsHelper
   def user_status(evaluator, challenge)
     if evaluator.is_a?(User)
-      user_status_for_existing_user(evaluator, challenge)
+      evaluator.status == 'active' ? "Available" : "Awaiting Approval"
     else
       "Invite Sent"
     end
@@ -17,16 +17,6 @@ module ManageEvaluatorsHelper
         count
     else
       0
-    end
-  end
-
-  private
-
-  def user_status_for_existing_user(user, challenge)
-    if challenge.challenge_phases_evaluators.exists?(user_id: user.id)
-      user.status == 'active' ? "Available" : "Awaiting Approval"
-    else
-      "Invite Sent"
     end
   end
 end

--- a/app/models/challenge_phases_evaluator.rb
+++ b/app/models/challenge_phases_evaluator.rb
@@ -15,4 +15,14 @@ class ChallengePhasesEvaluator < ApplicationRecord
   belongs_to :challenge
   belongs_to :phase
   belongs_to :user
+
+  validate :user_has_valid_role, if: -> { user.present? }
+
+  private
+
+  def user_has_valid_role
+    unless User::VALID_EVALUATOR_ROLES.include?(user.role)
+      errors.add(:user, "must have a valid evaluator role")
+    end
+  end
 end

--- a/app/models/challenge_phases_evaluator.rb
+++ b/app/models/challenge_phases_evaluator.rb
@@ -16,7 +16,7 @@ class ChallengePhasesEvaluator < ApplicationRecord
   belongs_to :phase
   belongs_to :user
 
-  validate :user_has_valid_role, if: -> { user.present? }
+  validate :user_has_valid_role
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -133,7 +133,7 @@ class User < ApplicationRecord
     if default_challenge_manager?(email)
       %w[challenge_manager pending]
     else
-      %w[solver active]
+      %w[evaluator pending]
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,10 @@
 #  recertification_expired_at :datetime
 #
 class User < ApplicationRecord
+  after_create :accept_evaluator_invitation
+
+  VALID_EVALUATOR_ROLES = %w[evaluator solver challenge_manager].freeze
+
   belongs_to :agency, optional: true
 
   has_many :challenges, dependent: :destroy
@@ -130,14 +134,25 @@ class User < ApplicationRecord
   end
 
   def self.default_role_and_status_for_email(email)
-    if default_challenge_manager?(email)
+    if EvaluatorInvitation.exists?(email: email)
+      %w[evaluator pending]
+    elsif default_challenge_manager?(email)
       %w[challenge_manager pending]
     else
-      %w[evaluator pending]
+      %w[solver active]
     end
   end
 
   def self.default_challenge_manager?(email)
     /\.(gov|mil)$/.match?(email)
+  end
+
+  private
+
+  def accept_evaluator_invitation
+    EvaluatorInvitation.where(email: self.email).each do |invite|
+      ChallengePhasesEvaluator.create(challenge: invite.challenge, phase: invite.phase, user: self)
+      invite.destroy
+    end
   end
 end

--- a/spec/controllers/manage_evaluators_controller_spec.rb
+++ b/spec/controllers/manage_evaluators_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ManageEvaluatorsController, type: :request do
   let(:challenge) { create(:challenge) }
   let(:phase) { create(:phase, challenge: challenge) }
   let(:evaluator) { create(:user, role: 'evaluator') }
-  let(:invitation) { create(:evaluator_invitation, challenge: challenge, phase: phase) }
+  let(:invitation) { create(:evaluator_invitation, challenge: challenge, phase: phase, email: 'invitation@example.com') }
 
   before do
     ChallengeManager.create(user: user, challenge: challenge)
@@ -84,15 +84,14 @@ RSpec.describe ManageEvaluatorsController, type: :request do
       end
     end
 
-    context 'when inviting an existing user with an invitation' do
+    context 'when inviting a user who is already an evaluator for the challenge phase' do
       let(:existing_user) { create(:user, role: 'evaluator', status: 'pending') }
-      let!(:invitation) { create(:evaluator_invitation, challenge: challenge, phase: phase, email: existing_user.email) }
 
       before do
         ChallengePhasesEvaluator.create!(challenge: challenge, phase: phase, user: existing_user)
       end
 
-      it 'adds the user as an evaluator without creating a new ChallengePhasesEvaluator' do
+      it 'it does not create an additional ChallengePhaseEvaluator' do
         expect {
           post challenge_manage_evaluators_path(challenge), params: {
             evaluator_invitation: {
@@ -100,12 +99,29 @@ RSpec.describe ManageEvaluatorsController, type: :request do
               phase_id: phase.id
             }
           }
-        }.not_to change(ChallengePhasesEvaluator, :count)
+        }.to_not change(ChallengePhasesEvaluator, :count)
 
         expect(ChallengePhasesEvaluator.where(challenge: challenge, phase: phase, user: existing_user).count).to eq(1)
-        expect(EvaluatorInvitation.find_by(id: invitation.id)).to be_present
         expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
         expect(flash[:notice]).to include("has already been added as an evaluator for this phase")
+      end
+    end
+
+    context 'when inviting a user who already has an invitation for the challenge phase' do
+      it 'does not create an additional EvaluatorInvitation' do
+        invitation # create existing invitation
+
+        expect {
+          post challenge_manage_evaluators_path(challenge), params: {
+            evaluator_invitation: {
+              email: invitation.email,
+              phase_id: phase.id
+            }
+          }
+        }.not_to change(EvaluatorInvitation, :count)
+
+        expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
+        expect(flash[:notice]).to include("An invitation to this challenge has already been sent to #{invitation.email}. Invitation has been resent.")
       end
     end
 
@@ -150,11 +166,7 @@ RSpec.describe ManageEvaluatorsController, type: :request do
     end
 
     context 'when adding an existing user with an invalid role' do
-      let(:existing_user) { create(:user, role: 'evaluator', status: 'pending') }
-
-      before do
-        existing_user.update_column(:role, 'admin') # invalid evaluator role
-      end
+      let(:existing_user) { create(:user, role: 'admin') }
 
       it 'does not add the user as an evaluator and returns an error' do
         initial_count = ChallengePhasesEvaluator.count

--- a/spec/controllers/manage_evaluators_controller_spec.rb
+++ b/spec/controllers/manage_evaluators_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ManageEvaluatorsController, type: :request do
     end
 
     context 'when inviting an existing user' do
-      let(:existing_user) { create(:user, role: 'evaluator') }
+      let(:existing_user) { create(:user, role: 'evaluator', status: 'pending') }
 
       it 'adds the user as an evaluator without creating a new invitation' do
         expect {
@@ -84,27 +84,64 @@ RSpec.describe ManageEvaluatorsController, type: :request do
       end
     end
 
-    context 'when inviting a new user' do
-      let(:new_user_params) do
-        {
-          evaluator_invitation: {
-            email: 'new_evaluator@example.com',
-            phase_id: phase.id,
-            first_name: 'New',
-            last_name: 'Evaluator',
-            last_invite_sent: Time.current
-          }
-        }
-      end
+    context 'when inviting an existing user with an invitation' do
+      let(:existing_user) { create(:user, role: 'evaluator', status: 'pending') }
+      let!(:invitation) { create(:evaluator_invitation, challenge: challenge, phase: phase, email: existing_user.email) }
 
-      it 'creates a new evaluator invitation' do
+      it 'adds the user as an evaluator and deletes only the specific invitation' do
         expect {
-          post challenge_manage_evaluators_path(challenge), params: new_user_params
-        }.to change(EvaluatorInvitation, :count).by(1)
+          post challenge_manage_evaluators_path(challenge), params: {
+            evaluator_invitation: {
+              email: existing_user.email,
+              phase_id: phase.id
+            }
+          }
+        }.to change(ChallengePhasesEvaluator, :count).by(1)
+          .and change(EvaluatorInvitation, :count).by(-1)
 
-        expect(ChallengePhasesEvaluator.count).to eq(0)
+        expect(EvaluatorInvitation.find_by(id: invitation.id)).to be_nil
         expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
-        expect(flash[:notice]).to include("Invitation sent to")
+        expect(flash[:notice]).to include("has been added as an evaluator for this phase")
+      end
+    end
+
+    context 'when adding an existing user with a non-evaluator role' do
+      let(:existing_user) { create(:user, role: 'solver', status: 'pending') }
+
+      it 'adds the user as an evaluator without changing their role' do
+        expect {
+          post challenge_manage_evaluators_path(challenge), params: {
+            evaluator_invitation: {
+              email: existing_user.email,
+              phase_id: phase.id
+            }
+          }
+        }.to change(ChallengePhasesEvaluator, :count).by(1)
+
+        existing_user.reload
+        expect(existing_user.role).to eq('solver')
+        expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
+        expect(flash[:notice]).to include("has been added as an evaluator for this phase")
+      end
+    end
+
+    context 'when adding a new user with default evaluator role' do
+      let(:existing_evaluator) { create(:user, role: 'evaluator', status: 'pending') }
+
+      it 'adds the user without changing their role' do
+        expect {
+          post challenge_manage_evaluators_path(challenge), params: {
+            evaluator_invitation: {
+              email: existing_evaluator.email,
+              phase_id: phase.id
+            }
+          }
+        }.to change(ChallengePhasesEvaluator, :count).by(1)
+
+        existing_evaluator.reload
+        expect(existing_evaluator.role).to eq('evaluator')
+        expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
+        expect(flash[:notice]).to include("has been added as an evaluator for this phase")
       end
     end
   end

--- a/spec/controllers/manage_evaluators_controller_spec.rb
+++ b/spec/controllers/manage_evaluators_controller_spec.rb
@@ -88,7 +88,11 @@ RSpec.describe ManageEvaluatorsController, type: :request do
       let(:existing_user) { create(:user, role: 'evaluator', status: 'pending') }
       let!(:invitation) { create(:evaluator_invitation, challenge: challenge, phase: phase, email: existing_user.email) }
 
-      it 'adds the user as an evaluator and deletes only the specific invitation' do
+      before do
+        ChallengePhasesEvaluator.create!(challenge: challenge, phase: phase, user: existing_user)
+      end
+
+      it 'adds the user as an evaluator without creating a new ChallengePhasesEvaluator' do
         expect {
           post challenge_manage_evaluators_path(challenge), params: {
             evaluator_invitation: {
@@ -96,12 +100,12 @@ RSpec.describe ManageEvaluatorsController, type: :request do
               phase_id: phase.id
             }
           }
-        }.to change(ChallengePhasesEvaluator, :count).by(1)
-          .and change(EvaluatorInvitation, :count).by(-1)
+        }.not_to change(ChallengePhasesEvaluator, :count)
 
-        expect(EvaluatorInvitation.find_by(id: invitation.id)).to be_nil
+        expect(ChallengePhasesEvaluator.where(challenge: challenge, phase: phase, user: existing_user).count).to eq(1)
+        expect(EvaluatorInvitation.find_by(id: invitation.id)).to be_present
         expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
-        expect(flash[:notice]).to include("has been added as an evaluator for this phase")
+        expect(flash[:notice]).to include("has already been added as an evaluator for this phase")
       end
     end
 
@@ -142,6 +146,29 @@ RSpec.describe ManageEvaluatorsController, type: :request do
         expect(existing_evaluator.role).to eq('evaluator')
         expect(response).to redirect_to(challenge_manage_evaluators_path(challenge, phase_id: phase.id))
         expect(flash[:notice]).to include("has been added as an evaluator for this phase")
+      end
+    end
+
+    context 'when adding an existing user with an invalid role' do
+      let(:existing_user) { create(:user, role: 'evaluator', status: 'pending') }
+
+      before do
+        existing_user.update_column(:role, 'admin') # invalid evaluator role
+      end
+
+      it 'does not add the user as an evaluator and returns an error' do
+        initial_count = ChallengePhasesEvaluator.count
+
+        post challenge_manage_evaluators_path(challenge), params: {
+          evaluator_invitation: {
+            email: existing_user.email,
+            phase_id: phase.id
+          }
+        }
+
+        expect(ChallengePhasesEvaluator.count).to eq(initial_count)
+        expect(response).to render_template(:index)
+        expect(flash[:alert]).to include("does not have a valid evaluator role")
       end
     end
   end

--- a/spec/models/challenge_phases_evaluator_spec.rb
+++ b/spec/models/challenge_phases_evaluator_spec.rb
@@ -62,4 +62,29 @@ RSpec.describe ChallengePhasesEvaluator, type: :model do
     expect(phase.evaluators).to include(user)
     expect(user.evaluated_phases).to include(phase)
   end
+
+  context "with invalid user role" do
+    let(:invalid_user) { create(:user, role: User::VALID_EVALUATOR_ROLES.first) }
+
+    before do
+      invalid_user.update_column(:role, 'admin')
+    end
+
+    it "is invalid" do
+      evaluator = build(:challenge_phases_evaluator, challenge:, phase:, user: invalid_user)
+      expect(evaluator).not_to be_valid
+      expect(evaluator.errors[:user]).to include("must have a valid evaluator role")
+    end
+  end
+
+  User::VALID_EVALUATOR_ROLES.each do |role|
+    context "with #{role} role" do
+      let(:valid_user) { create(:user, role: role) }
+
+      it "is valid" do
+        evaluator = build(:challenge_phases_evaluator, challenge:, phase:, user: valid_user)
+        expect(evaluator).to be_valid
+      end
+    end
+  end
 end

--- a/spec/models/challenge_phases_evaluator_spec.rb
+++ b/spec/models/challenge_phases_evaluator_spec.rb
@@ -21,24 +21,6 @@ RSpec.describe ChallengePhasesEvaluator, type: :model do
     expect(challenge.evaluators).to include(user)
   end
 
-  it "requires a challenge" do
-    evaluator = build(:challenge_phases_evaluator, challenge: nil)
-    expect(evaluator).not_to be_valid
-    expect(evaluator.errors[:challenge]).to include("must exist")
-  end
-
-  it "requires a phase" do
-    evaluator = build(:challenge_phases_evaluator, phase: nil)
-    expect(evaluator).not_to be_valid
-    expect(evaluator.errors[:phase]).to include("must exist")
-  end
-
-  it "requires a user" do
-    evaluator = build(:challenge_phases_evaluator, user: nil)
-    expect(evaluator).not_to be_valid
-    expect(evaluator.errors[:user]).to include("must exist")
-  end
-
   it "allows multiple evaluators for the same challenge and phase" do
     challenge = create(:challenge)
     phase = create(:phase, challenge:)
@@ -64,11 +46,7 @@ RSpec.describe ChallengePhasesEvaluator, type: :model do
   end
 
   context "with invalid user role" do
-    let(:invalid_user) { create(:user, role: User::VALID_EVALUATOR_ROLES.first) }
-
-    before do
-      invalid_user.update_column(:role, 'admin')
-    end
+    let(:invalid_user) { create(:user, role: 'admin') }
 
     it "is invalid" do
       evaluator = build(:challenge_phases_evaluator, challenge:, phase:, user: invalid_user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe User do
       expect(created_user.status).to eq("pending")
     end
 
-    it 'creates active solver user if no matching token or email and non .gov email' do
+    it 'creates pending evaluator user if no matching token or email and non .gov email' do
       email = non_gov_userinfo[0]["email"]
       token = non_gov_userinfo[0]["sub"]
 
@@ -155,8 +155,8 @@ RSpec.describe User do
 
       expect(created_user.email).to eq(email)
       expect(created_user.token).to eq(token)
-      expect(created_user.role).to eq("solver")
-      expect(created_user.status).to eq("active")
+      expect(created_user.role).to eq("evaluator")
+      expect(created_user.status).to eq("pending")
     end
 
     it 'update user with token if matching email but no token set (from admin creation)' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe User do
       expect(created_user.status).to eq("pending")
     end
 
-    it 'creates pending evaluator user if no matching token or email and non .gov email' do
+    it 'creates active solver user if no matching token or email and non .gov email' do
       email = non_gov_userinfo[0]["email"]
       token = non_gov_userinfo[0]["sub"]
 
@@ -155,8 +155,8 @@ RSpec.describe User do
 
       expect(created_user.email).to eq(email)
       expect(created_user.token).to eq(token)
-      expect(created_user.role).to eq("evaluator")
-      expect(created_user.status).to eq("pending")
+      expect(created_user.role).to eq("solver")
+      expect(created_user.status).to eq("active")
     end
 
     it 'update user with token if matching email but no token set (from admin creation)' do
@@ -172,6 +172,82 @@ RSpec.describe User do
       expect(updated_user.id).to eq(user.id)
       expect(updated_user.email).to eq(email)
       expect(updated_user.token).to eq(token)
+    end
+  end
+
+  describe '#accept_evaluator_invitation' do
+    let(:challenge1) { create(:challenge) }
+    let(:challenge2) { create(:challenge) }
+    let(:phase1) { create(:phase, challenge: challenge1) }
+    let(:phase2) { create(:phase, challenge: challenge1) }
+    let(:phase3) { create(:phase, challenge: challenge2) }
+    let(:user_email) { 'test@example.com' }
+
+    context 'when there are existing evaluator invitations' do
+      before do
+        create(:evaluator_invitation, challenge: challenge1, phase: phase1, email: user_email)
+        create(:evaluator_invitation, challenge: challenge1, phase: phase2, email: user_email)
+        create(:evaluator_invitation, challenge: challenge2, phase: phase3, email: user_email)
+      end
+
+      it 'creates ChallengePhasesEvaluator records for all invitations when user is created' do
+        expect {
+          create(:user, email: user_email, role: 'evaluator')
+        }.to change(ChallengePhasesEvaluator, :count).by(3)
+      end
+
+      it 'destroys all EvaluatorInvitation records when user is created' do
+        expect {
+          create(:user, email: user_email, role: 'evaluator')
+        }.to change(EvaluatorInvitation, :count).by(-3)
+      end
+
+      it 'associates the new user with the correct challenges and phases' do
+        user = create(:user, email: user_email, role: 'evaluator')
+        expect(user.challenge_phases_evaluators.count).to eq(3)
+        expect(user.challenge_phases_evaluators.map(&:challenge)).to contain_exactly(challenge1, challenge1, challenge2)
+        expect(user.challenge_phases_evaluators.map(&:phase)).to contain_exactly(phase1, phase2, phase3)
+      end
+    end
+
+    context 'when there are no existing evaluator invitations' do
+      it 'does not create any ChallengePhasesEvaluator records' do
+        expect {
+          create(:user, email: user_email)
+        }.not_to change(ChallengePhasesEvaluator, :count)
+      end
+
+      it 'does not destroy any EvaluatorInvitation records' do
+        expect {
+          create(:user, email: user_email)
+        }.not_to change(EvaluatorInvitation, :count)
+      end
+    end
+
+    context 'when there are invitations for multiple challenges and phases' do
+      before do
+        create(:evaluator_invitation, challenge: challenge1, phase: phase1, email: user_email)
+        create(:evaluator_invitation, challenge: challenge2, phase: phase3, email: user_email)
+      end
+
+      it 'creates ChallengePhasesEvaluator records for all invitations' do
+        expect {
+          create(:user, email: user_email, role: 'evaluator')
+        }.to change(ChallengePhasesEvaluator, :count).by(2)
+      end
+
+      it 'destroys all EvaluatorInvitation records' do
+        expect {
+          create(:user, email: user_email, role: 'evaluator')
+        }.to change(EvaluatorInvitation, :count).by(-2)
+      end
+
+      it 'associates the user with the correct challenges and phases' do
+        user = create(:user, email: user_email, role: 'evaluator')
+        expect(user.challenge_phases_evaluators.count).to eq(2)
+        expect(user.challenge_phases_evaluators.map(&:challenge)).to contain_exactly(challenge1, challenge2)
+        expect(user.challenge_phases_evaluators.map(&:phase)).to contain_exactly(phase1, phase3)
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -224,30 +224,5 @@ RSpec.describe User do
       end
     end
 
-    context 'when there are invitations for multiple challenges and phases' do
-      before do
-        create(:evaluator_invitation, challenge: challenge1, phase: phase1, email: user_email)
-        create(:evaluator_invitation, challenge: challenge2, phase: phase3, email: user_email)
-      end
-
-      it 'creates ChallengePhasesEvaluator records for all invitations' do
-        expect {
-          create(:user, email: user_email, role: 'evaluator')
-        }.to change(ChallengePhasesEvaluator, :count).by(2)
-      end
-
-      it 'destroys all EvaluatorInvitation records' do
-        expect {
-          create(:user, email: user_email, role: 'evaluator')
-        }.to change(EvaluatorInvitation, :count).by(-2)
-      end
-
-      it 'associates the user with the correct challenges and phases' do
-        user = create(:user, email: user_email, role: 'evaluator')
-        expect(user.challenge_phases_evaluators.count).to eq(2)
-        expect(user.challenge_phases_evaluators.map(&:challenge)).to contain_exactly(challenge1, challenge2)
-        expect(user.challenge_phases_evaluators.map(&:phase)).to contain_exactly(phase1, phase3)
-      end
-    end
   end
 end


### PR DESCRIPTION
#245 

Update the invited evaluator's user setup requirements:
- A user with a new account defaults to role of evaluator with status pending. 
- An evaluator is associated with the phase they are assigned through `ChallengePhasesEvaluator`
- When an new evaluator user is successfully registered, their `EvaluatorInvitation` record is deleted and they are then associated to the Phase they successfully registered for through `ChallengePhasesEvaluator`
- An admin can change a new evaluator user's status to `active`

Tests added to cover changes.

No UI changes/No WAVE screenshot