### PR TITLE
[304] Collapsible Column Layout

### DIFF
--- a/app/assets/uswds/_uswds-theme.scss
+++ b/app/assets/uswds/_uswds-theme.scss
@@ -57,6 +57,10 @@ Add a list of changed settings in the form $setting: value.
   filter: invert(99%) sepia(2%) saturate(3661%) hue-rotate(191deg) brightness(117%) contrast(80%);
 }
 
+.width-half {
+  width: 50%;
+}
+
 .usa-social-link {
   background-color: white;
 }

--- a/app/javascript/controllers/hotdog_controller.js
+++ b/app/javascript/controllers/hotdog_controller.js
@@ -2,21 +2,33 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="hotdog"
 export default class extends Controller {
-  static targets = ["rightPane", "collapseBar", "leftPane", "expandBar"];
+  static targets = ["rightPane", "leftPane", "hotdogCollapse", "hotdogExpand", "burgerCollapse", "burgerExpand", "burgerCollapsible"];
 
-  handleCollapse(e) {
+  hotdogCollapse(e) {
     this.rightPaneTarget.classList.add("display-none")
-    this.collapseBarTarget.classList.add("display-none")
-    this.expandBarTarget.classList.remove("display-none")
+    this.hotdogCollapseTarget.classList.add("display-none")
+    this.hotdogExpandTarget.classList.remove("display-none")
     this.leftPaneTarget.classList.add("width-full")
     this.leftPaneTarget.classList.remove("width-half")
   }
 
-  handleExpand(e) {
+  hotdogExpand(e) {
     this.rightPaneTarget.classList.remove("display-none")
-    this.collapseBarTarget.classList.remove("display-none")
-    this.expandBarTarget.classList.add("display-none")
+    this.hotdogCollapseTarget.classList.remove("display-none")
+    this.hotdogExpandTarget.classList.add("display-none")
     this.leftPaneTarget.classList.remove("width-full")
     this.leftPaneTarget.classList.add("width-half")
+  }
+
+  burgerCollapse(e) {
+    this.burgerCollapsibleTarget.classList.add("display-none")
+    this.burgerCollapseTarget.classList.add("display-none")
+    this.burgerExpandTarget.classList.remove("display-none")
+  }
+
+  burgerExpand(e) {
+    this.burgerCollapsibleTarget.classList.remove("display-none")
+    this.burgerCollapseTarget.classList.remove("display-none")
+    this.burgerExpandTarget.classList.add("display-none")
   }
 }

--- a/app/javascript/controllers/hotdog_controller.js
+++ b/app/javascript/controllers/hotdog_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="submission-detail"
+// Connects to data-controller="hotdog"
 export default class extends Controller {
   static targets = ["rightPane", "collapseBar", "leftPane", "expandBar"];
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -2,12 +2,16 @@
 // Run that command whenever you add a new controller or create them with
 // ./bin/rails generate stimulus controllerName
 
-import { application } from "./application";
-
-import EvaluationFormController from "./evaluation_form_controller";
-import EvaluationCriteriaController from "./evaluation_criteria_controller";
-application.register("evaluation-form", EvaluationFormController);
-application.register("evaluation-criteria", EvaluationCriteriaController);
+import { application } from "./application"
 
 import DeleteEvaluatorModalController from "./delete_evaluator_modal_controller"
 application.register("delete-evaluator-modal", DeleteEvaluatorModalController)
+
+import EvaluationCriteriaController from "./evaluation_criteria_controller"
+application.register("evaluation-criteria", EvaluationCriteriaController)
+
+import EvaluationFormController from "./evaluation_form_controller"
+application.register("evaluation-form", EvaluationFormController)
+
+import SubmissionDetailController from "./submission_detail_controller"
+application.register("submission-detail", SubmissionDetailController)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -13,5 +13,5 @@ application.register("evaluation-criteria", EvaluationCriteriaController)
 import EvaluationFormController from "./evaluation_form_controller"
 application.register("evaluation-form", EvaluationFormController)
 
-import SubmissionDetailController from "./submission_detail_controller"
-application.register("submission-detail", SubmissionDetailController)
+import HotdogController from "./hotdog_controller"
+application.register("hotdog", HotdogController)

--- a/app/javascript/controllers/submission_detail_controller.js
+++ b/app/javascript/controllers/submission_detail_controller.js
@@ -1,0 +1,22 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="submission-detail"
+export default class extends Controller {
+  static targets = ["rightPane", "collapseBar", "leftPane", "expandBar"];
+
+  handleCollapse(e) {
+    this.rightPaneTarget.classList.add("display-none")
+    this.collapseBarTarget.classList.add("display-none")
+    this.expandBarTarget.classList.remove("display-none")
+    this.leftPaneTarget.classList.add("width-full")
+    this.leftPaneTarget.classList.remove("width-half")
+  }
+
+  handleExpand(e) {
+    this.rightPaneTarget.classList.remove("display-none")
+    this.collapseBarTarget.classList.remove("display-none")
+    this.expandBarTarget.classList.add("display-none")
+    this.leftPaneTarget.classList.remove("width-full")
+    this.leftPaneTarget.classList.add("width-half")
+  }
+}

--- a/app/views/layouts/_hotdog.html.erb
+++ b/app/views/layouts/_hotdog.html.erb
@@ -3,7 +3,7 @@
     <div data-hotdog-target="burgerCollapsible">
         <%= render partial: right %>
     </div>
-    <div class="bg-primary-darker margin-y-5 width-full cursor-pointer padding-1" data-action="click->hotdog#burgerCollapse" data-hotdog-target="burgerCollapse">
+    <div class="bg-primary-darker margin-y-1 width-full cursor-pointer padding-1" data-action="click->hotdog#burgerCollapse" data-hotdog-target="burgerCollapse">
         <%= image_tag('images/usa-icons/arrow_upward.svg', class: "usa-icon--size-3 icon-white margin-bottom-05", alt: "Hide #{name}") %>
         <span class="text-white width-15 display-inline-block">Hide <%= name %></span>
     </div>

--- a/app/views/layouts/_hotdog.html.erb
+++ b/app/views/layouts/_hotdog.html.erb
@@ -1,0 +1,14 @@
+<div class="display-flex flex-row width-full border-top-1px" data-controller="hotdog">
+  <div class="width-half" data-hotdog-target="leftPane">
+    <%= render partial: left %>
+  </div>  
+  <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer" data-action="click->hotdog#handleCollapse" data-hotdog-target="collapseBar">
+    <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Collapse Details") %>
+  </div>
+  <div class="bg-primary-darker margin-left-5 width-3 cursor-pointer display-none" data-action="click->hotdog#handleExpand" data-hotdog-target="expandBar">
+    <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white", alt: "Expand Details") %>
+  </div>    
+  <div class="width-half" data-hotdog-target="rightPane">  
+    <%= render partial: right %>
+  </div>  
+</div>

--- a/app/views/layouts/_hotdog.html.erb
+++ b/app/views/layouts/_hotdog.html.erb
@@ -1,14 +1,31 @@
-<div class="display-flex flex-row width-full border-top-1px" data-controller="hotdog">
-  <div class="width-half" data-hotdog-target="leftPane">
+<%# burger orientation, for mobile %>
+<div class="tablet:display-none" data-controller="hotdog">
+    <div data-hotdog-target="burgerCollapsible">
+        <%= render partial: right %>
+    </div>
+    <div class="bg-primary-darker margin-y-5 width-full cursor-pointer padding-1" data-action="click->hotdog#burgerCollapse" data-hotdog-target="burgerCollapse">
+        <%= image_tag('images/usa-icons/arrow_upward.svg', class: "usa-icon--size-3 icon-white margin-bottom-05", alt: "Hide #{name}") %>
+        <span class="text-white width-15 display-inline-block">Hide <%= name %></span>
+    </div>
+    <div class="bg-primary-darker margin-y-1 width-full cursor-pointer display-none padding-1" data-action="click->hotdog#burgerExpand" data-hotdog-target="burgerExpand">
+        <%= image_tag('images/usa-icons/arrow_downward.svg', class: "usa-icon--size-3 icon-white margin-bottom-05", alt: "Show #{name}") %>
+        <span class="text-white width-15 display-inline-block">Show <%= name %></span>
+    </div>    
     <%= render partial: left %>
-  </div>  
-  <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer" data-action="click->hotdog#handleCollapse" data-hotdog-target="collapseBar">
-    <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Collapse Details") %>
-  </div>
-  <div class="bg-primary-darker margin-left-5 width-3 cursor-pointer display-none" data-action="click->hotdog#handleExpand" data-hotdog-target="expandBar">
-    <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white", alt: "Expand Details") %>
-  </div>    
-  <div class="width-half" data-hotdog-target="rightPane">  
-    <%= render partial: right %>
-  </div>  
+</div>
+
+<%# hotdog orientation, for tablet and above %>
+<div class="display-none tablet:display-flex flex-row width-full border-top-1px" data-controller="hotdog">
+    <div class="width-half" data-hotdog-target="leftPane">
+        <%= render partial: left %>
+    </div>  
+    <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer" data-action="click->hotdog#hotdogCollapse" data-hotdog-target="hotdogCollapse">
+        <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Hide #{name}") %>
+    </div>
+    <div class="bg-primary-darker margin-left-5 width-3 cursor-pointer display-none" data-action="click->hotdog#hotdogExpand" data-hotdog-target="hotdogExpand">
+        <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white", alt: "Show #{name}") %>
+    </div>    
+    <div class="width-half" data-hotdog-target="rightPane">  
+        <%= render partial: right %>
+    </div>  
 </div>

--- a/app/views/submissions/_comment_form.html.erb
+++ b/app/views/submissions/_comment_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: @submission, url: submission_path(@submission), class: "width-mobile-lg") do |form| %>
+<%= form_with(model: @submission, url: submission_path(@submission), class: "max-width-mobile-lg") do |form| %>
     <div class="usa-form-group">
         <%= form.label :comments, "Comments and notes:", class: "usa-label" %>
         <%= form.text_area :comments, class: "usa-textarea", default: @submission.comments %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,4 +1,4 @@
 <h1>Submission ID <%= @submission.id %></h1>
 <p class="text-normal">View submission information and assign evaluators to evaluate the submission.</p>
 
-<%= render partial: "layouts/hotdog", locals: {left: 'submissions/comment_form', right: 'submissions/submission_materials'} %>
+<%= render partial: "layouts/hotdog", locals: {left: 'submissions/comment_form', right: 'submissions/submission_materials', name: 'Submission Materials'} %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,14 +1,17 @@
 <h1>Submission ID <%= @submission.id %></h1>
 <p class="text-normal">View submission information and assign evaluators to evaluate the submission.</p>
 
-<div class="display-flex flex-row width-full border-top-1px">
-  <div style="width: 50%">
+<div class="display-flex flex-row width-full border-top-1px" data-controller="submission-detail">
+  <div class="width-half" data-submission-detail-target="leftPane">
     <%= render partial: "comment_form" %>
   </div>  
-  <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer">
-    <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Back to previous page") %>
-  </div>  
-  <div style="width: 50%">  
+  <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer" data-action="click->submission-detail#handleCollapse" data-submission-detail-target="collapseBar">
+    <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Collapse Details") %>
+  </div>
+  <div class="bg-primary-darker margin-left-5 width-3 cursor-pointer display-none" data-action="click->submission-detail#handleExpand" data-submission-detail-target="expandBar">
+    <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white", alt: "Expand Details") %>
+  </div>    
+  <div class="width-half" data-submission-detail-target="rightPane">  
     <%= render partial: "submission_materials" %>
   </div>  
 </div>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,5 +1,14 @@
 <h1>Submission ID <%= @submission.id %></h1>
 <p class="text-normal">View submission information and assign evaluators to evaluate the submission.</p>
 
-<%= render partial: "submission_materials" %>
-<%= render partial: "comment_form" %>
+<div class="display-flex flex-row width-full border-top-1px">
+  <div style="width: 50%">
+    <%= render partial: "comment_form" %>
+  </div>  
+  <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer">
+    <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Back to previous page") %>
+  </div>  
+  <div style="width: 50%">  
+    <%= render partial: "submission_materials" %>
+  </div>  
+</div>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,17 +1,4 @@
 <h1>Submission ID <%= @submission.id %></h1>
 <p class="text-normal">View submission information and assign evaluators to evaluate the submission.</p>
 
-<div class="display-flex flex-row width-full border-top-1px" data-controller="submission-detail">
-  <div class="width-half" data-submission-detail-target="leftPane">
-    <%= render partial: "comment_form" %>
-  </div>  
-  <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer" data-action="click->submission-detail#handleCollapse" data-submission-detail-target="collapseBar">
-    <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Collapse Details") %>
-  </div>
-  <div class="bg-primary-darker margin-left-5 width-3 cursor-pointer display-none" data-action="click->submission-detail#handleExpand" data-submission-detail-target="expandBar">
-    <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white", alt: "Expand Details") %>
-  </div>    
-  <div class="width-half" data-submission-detail-target="rightPane">  
-    <%= render partial: "submission_materials" %>
-  </div>  
-</div>
+<%= render partial: "layouts/hotdog", locals: {left: 'submissions/comment_form', right: 'submissions/submission_materials'} %>


### PR DESCRIPTION
Implements a vertically collapsible 2-column layout, lovingly named 'hotdog' after folding paper hotdog-style. 

automatically becomes a horizontally collapsible 'hamburger' on mobile. 

Implemented on the submissions detail page, can be used anywhere.

I believe the current codeclimate error is unhelpful in this case and should be overridden. 

<img width="1310" alt="Screen Shot 2024-12-04 at 7 33 45 PM" src="https://github.com/user-attachments/assets/f08dea74-878c-4fb6-8d0a-71bd9cb01f5d">
<img width="1310" alt="Screen Shot 2024-12-04 at 7 34 02 PM" src="https://github.com/user-attachments/assets/5250aac8-4377-40cd-9ae1-b939799c4f17">

![Screen Shot 2024-12-05 at 11 20 52 AM](https://github.com/user-attachments/assets/dcbcdb9a-41ec-4bf2-a261-c9a3e2bd95e2)

![Screen Shot 2024-12-05 at 11 20 23 AM](https://github.com/user-attachments/assets/751a6a6e-a615-433c-88b1-b1ba0e97bf33)

<img width="1299" alt="Screen Shot 2024-12-04 at 7 34 26 PM" src="https://github.com/user-attachments/assets/38aef920-3825-41ee-a104-8b89db225f1f">
