### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/app/models/login_gov.rb
+++ b/app/models/login_gov.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'uri'
 
 # LoginGov manages authentication with the external login.gov service
@@ -105,11 +106,12 @@ class LoginGov
   end
 
   def validate_jwks_uri(uri)
-    allowed_hostnames = ["trusted-domain.com"]
+    idp_host = URI.parse(config[:idp_host]).host
+    allowed_hostnames = [idp_host]
     uri_host = URI.parse(uri).host
-    unless allowed_hostnames.include?(uri_host)
-      raise LoginApiError.new("Invalid jwks_uri", code: 400, body: "The jwks_uri is not allowed.")
-    end
+    return if allowed_hostnames.include?(uri_host)
+
+    raise LoginApiError.new("Invalid jwks_uri", code: 400, body: "The jwks_uri is not allowed.")
   end
 
   def read_private_key

--- a/app/models/login_gov.rb
+++ b/app/models/login_gov.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'uri'
 
 # LoginGov manages authentication with the external login.gov service
 # login.gov is a single-signon (SSO) identity provider (IdP) for GSA.
@@ -72,6 +73,7 @@ class LoginGov
 
     # fetch the public_key from the well-known configuration jwks_uri
     jwks_uri = openid_config.fetch("jwks_uri")
+    validate_jwks_uri(jwks_uri)
     public_key = get_public_key(jwks_uri)
 
     # build the client assertion
@@ -100,6 +102,14 @@ class LoginGov
     end
 
     JSON.parse(response.body)
+  end
+
+  def validate_jwks_uri(uri)
+    allowed_hostnames = ["trusted-domain.com"]
+    uri_host = URI.parse(uri).host
+    unless allowed_hostnames.include?(uri_host)
+      raise LoginApiError.new("Invalid jwks_uri", code: 400, body: "The jwks_uri is not allowed.")
+    end
   end
 
   def read_private_key


### PR DESCRIPTION
Fixes [https://github.com/GSA/Challenge_platform/security/code-scanning/1](https://github.com/GSA/Challenge_platform/security/code-scanning/1)

To fix the problem, we need to validate the `jwks_uri` before using it in the HTTP request. One way to do this is to ensure that the `jwks_uri` is within a specific domain or matches a specific pattern. This can be done by checking the hostname of the `jwks_uri` against a whitelist of allowed hostnames or by using a regular expression to validate the URL format.

We will add a method to validate the `jwks_uri` and call this method before making the HTTP request. If the `jwks_uri` is not valid, we will raise an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
