### PR TITLE
[293] Load more Pagination on Submissions list

### DIFF
--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -17,6 +17,18 @@ class PhasesController < ApplicationController
 
     apply_filters
     apply_sorting
+
+    @filtered_count = @submissions.unscope(:group).distinct.count(:id)
+    @submissions = paginate_submissions(@submissions)
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render partial: 'submissions_table_rows',
+               locals: { submissions: @submissions },
+               formats: [:html]
+      end
+    end
   end
 
   private
@@ -100,5 +112,11 @@ class PhasesController < ApplicationController
     when 'submission_id_low_to_high'
       @submissions = @submissions.order(id: :asc)
     end
+  end
+
+  def paginate_submissions(submissions)
+    page = (params[:page] || 1).to_i
+    per_page = 20
+    submissions.offset((page - 1) * per_page).limit(per_page)
   end
 end

--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -22,11 +22,14 @@ class PhasesController < ApplicationController
     @submissions = paginate_submissions(@submissions)
 
     respond_to do |format|
-      format.html
-      format.json do
-        render partial: 'submissions_table_rows',
-               locals: { submissions: @submissions },
-               formats: [:html]
+      format.html do
+        if params[:partial]
+          render partial: 'submissions_table_rows',
+                 locals: { submissions: @submissions },
+                 formats: [:html]
+        else
+          render :submissions
+        end
       end
     end
   end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -19,6 +19,9 @@ application.register("hotdog", HotdogController);
 import SubmissionDetailsController from "./submission_details_controller";
 application.register("submission-details", SubmissionDetailsController);
 
+import LoadMoreController from "./load_more_controller";
+application.register("load-more", LoadMoreController);
+
 import ModalController from "./modal_controller";
 application.register("modal", ModalController);
 

--- a/app/javascript/controllers/load_more_controller.js
+++ b/app/javascript/controllers/load_more_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["container", "loadMoreButton"]
+  static values = { 
+    page: Number,
+    totalCount: Number
+  }
+
+  connect() {
+    this.pageValue = 1
+    this.checkHasMoreSubmissions()
+  }
+
+  async loadMore() {
+    this.pageValue++
+    
+    try {
+      const url = new URL(window.location.href)
+      url.searchParams.set('page', this.pageValue)
+      url.searchParams.set('format', 'json')
+      
+      const response = await fetch(url)
+      if (!response.ok) throw new Error('Network response was not ok')
+      
+      const html = await response.text()
+      this.containerTarget.insertAdjacentHTML('beforeend', html)
+      this.checkHasMoreSubmissions()
+    } catch (error) {
+      console.error("Error loading more submissions:", error)
+    }
+  }
+
+  checkHasMoreSubmissions() {
+    const rows = this.containerTarget.querySelectorAll('tr')
+    if (rows.length >= this.totalCountValue) {
+      this.loadMoreButtonTarget.classList.add('display-none')
+    }
+  }
+}

--- a/app/javascript/controllers/load_more_controller.js
+++ b/app/javascript/controllers/load_more_controller.js
@@ -18,9 +18,14 @@ export default class extends Controller {
     try {
       const url = new URL(window.location.href)
       url.searchParams.set('page', this.pageValue)
-      url.searchParams.set('format', 'json')
+      url.searchParams.set('partial', 'true')
       
-      const response = await fetch(url)
+      const response = await fetch(url, {
+        headers: {
+          'Accept': 'text/html',
+          'X-Requested-With': 'XMLHttpRequest'
+        }
+      })
       if (!response.ok) throw new Error('Network response was not ok')
       
       const html = await response.text()

--- a/app/views/phases/_submissions_table.html.erb
+++ b/app/views/phases/_submissions_table.html.erb
@@ -8,7 +8,11 @@
 
 <%= render partial: "phases/sort_and_filter" %>
 
-<table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
+<div data-controller="load-more" 
+     data-load-more-url-value="<%= submissions_phase_path(@phase, format: :json) %>"
+     data-load-more-total-count-value="<%= @filtered_count %>">
+
+  <table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
     <thead>
       <tr>
         <th scope="col">Submission ID</th>
@@ -19,78 +23,17 @@
         <th scope="col"><span class="usa-sr-only">View Submission</span></th>
       </tr>
     </thead>
-    <tbody>
-      <% @submissions.each do |submission| %>
-          <tr data-submission-id="<%= submission.id %>">
-            <th data-label="Submission ID" scope="row">
-              <span class="mobile-lg:display-none">Submission ID </span><%= submission.id %>
-            </th>
-            <td data-label="Eligible for Evaluation">
-              <div class="display-flex flex-align-center">  
-                <% if submission.eligible_for_evaluation? %>
-                  <input type="checkbox" disabled checked class="display-none mobile-lg:display-block">
-                  <div class="mobile-lg:display-none">
-                      <%= image_tag(
-                          "images/usa-icons/verified.svg",
-                          class: "usa-icon--size-3 margin-right-1",
-                          alt: ""
-                      )%>
-                      <span class="text-top">Eligible for Evaluation</span>
-                  </div>
-                <% else  %>
-                    <input type="checkbox" disabled class="display-none mobile-lg:display-block">
-                    <div class="mobile-lg:display-none">
-                        <%= image_tag(
-                            "images/usa-icons/highlight_off.svg",
-                            class: "usa-icon--size-3 margin-right-1",
-                            alt: ""
-                        )%>
-                        <span class="text-top">Not Eligible for Evaluation</span>
-                    </div>    
-                <% end %>
-              </div>  
-            </td>
-            <td data-label="Selected to Advance">
-              <div class="display-flex flex-align-center">  
-                <% if submission.selected_to_advance? %>
-                    <input type="checkbox" disabled checked class="display-none mobile-lg:display-block">
-                    <div class="mobile-lg:display-none">
-                        <%= image_tag(
-                            "images/usa-icons/star.svg",
-                            class: "usa-icon--size-3 margin-right-1",
-                            alt: ""
-                        )%>
-                        <span class="text-top">Selected to Advance</span>
-                    </div>
-                <% else  %>
-                    <input type="checkbox" disabled class="display-none mobile-lg:display-block">
-                    <div class="mobile-lg:display-none">
-                        <%= image_tag(
-                            "images/usa-icons/star_outline.svg",
-                            class: "usa-icon--size-3 margin-right-1",
-                            alt: ""
-                        )%>
-                        <span class="text-top">Not Selected to Advance</span>
-                    </div>    
-                <% end %>
-              </div>  
-            </td>
-            <td data-label="Assigned Evaluators">
-                No evaluators assigned to this submission
-            </td>
-            <td data-label="Average Score" data-score="<%= score = submission.average_score %>">
-              <%= score %>
-            </td>
-            <td>
-              <div class="display-flex flex-no-wrap grid-row grid-gap-1">
-                <%= link_to submission_path(submission) do %>
-                    <button class="usa-button font-body-2xs text-no-wrap">
-                        View Submission
-                    </button>
-                <% end %>    
-              </div>  
-            </td>  
-          </tr>
-      <% end %>  
+    <tbody data-load-more-target="container">
+      <%= render partial: "submissions_table_rows", locals: { submissions: @submissions } %>
     </tbody>
   </table>
+
+  <div class="display-flex flex-justify-center margin-top-6 margin-bottom-6 width-full">
+    <button class="usa-button mobile:width-mobile" 
+            data-load-more-target="loadMoreButton"
+            data-action="click->load-more#loadMore"
+            aria-label="Load more submissions">
+      Load more
+    </button>
+  </div>
+</div>

--- a/app/views/phases/_submissions_table.html.erb
+++ b/app/views/phases/_submissions_table.html.erb
@@ -8,8 +8,7 @@
 
 <%= render partial: "phases/sort_and_filter" %>
 
-<div data-controller="load-more" 
-     data-load-more-url-value="<%= submissions_phase_path(@phase, format: :json) %>"
+<div data-controller="load-more"
      data-load-more-total-count-value="<%= @filtered_count %>">
 
   <table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">

--- a/app/views/phases/_submissions_table_rows.html.erb
+++ b/app/views/phases/_submissions_table_rows.html.erb
@@ -1,0 +1,72 @@
+<% @submissions.each do |submission| %>
+    <tr data-submission-id="<%= submission.id %>">
+      <th data-label="Submission ID" scope="row">
+        <span class="mobile-lg:display-none">Submission ID </span><%= submission.id %>
+      </th>
+      <td data-label="Eligible for Evaluation">
+        <div class="display-flex flex-align-center">  
+          <% if submission.eligible_for_evaluation? %>
+            <input type="checkbox" disabled checked class="display-none mobile-lg:display-block">
+            <div class="mobile-lg:display-none">
+                <%= image_tag(
+                    "images/usa-icons/verified.svg",
+                    class: "usa-icon--size-3 margin-right-1",
+                    alt: ""
+                )%>
+                <span class="text-top">Eligible for Evaluation</span>
+            </div>
+          <% else  %>
+              <input type="checkbox" disabled class="display-none mobile-lg:display-block">
+              <div class="mobile-lg:display-none">
+                  <%= image_tag(
+                      "images/usa-icons/highlight_off.svg",
+                      class: "usa-icon--size-3 margin-right-1",
+                      alt: ""
+                  )%>
+                  <span class="text-top">Not Eligible for Evaluation</span>
+              </div>    
+          <% end %>
+        </div>  
+      </td>
+      <td data-label="Selected to Advance">
+        <div class="display-flex flex-align-center">  
+          <% if submission.selected_to_advance? %>
+              <input type="checkbox" disabled checked class="display-none mobile-lg:display-block">
+              <div class="mobile-lg:display-none">
+                  <%= image_tag(
+                      "images/usa-icons/star.svg",
+                      class: "usa-icon--size-3 margin-right-1",
+                      alt: ""
+                  )%>
+                  <span class="text-top">Selected to Advance</span>
+              </div>
+          <% else  %>
+              <input type="checkbox" disabled class="display-none mobile-lg:display-block">
+              <div class="mobile-lg:display-none">
+                  <%= image_tag(
+                      "images/usa-icons/star_outline.svg",
+                      class: "usa-icon--size-3 margin-right-1",
+                      alt: ""
+                  )%>
+                  <span class="text-top">Not Selected to Advance</span>
+              </div>    
+          <% end %>
+        </div>  
+      </td>
+      <td data-label="Assigned Evaluators">
+          No evaluators assigned to this submission
+      </td>
+      <td data-label="Average Score" data-score="<%= score = submission.average_score %>">
+        <%= score %>
+      </td>
+      <td>
+        <div class="display-flex flex-no-wrap grid-row grid-gap-1">
+          <%= link_to submission_path(submission) do %>
+              <button class="usa-button font-body-2xs text-no-wrap">
+                  View Submission
+              </button>
+          <% end %>    
+        </div>  
+      </td>  
+    </tr>
+<% end %>

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -244,12 +244,14 @@ RSpec.describe "Submissions" do
       it 'returns first page of submissions' do
         get submissions_phase_path(phase)
         expect(response.body).to have_css('tr[data-submission-id]', count: 20)
+        expect(response.body).to have_button('Load more')
       end
 
-      it 'returns next page of submissions via JSON' do
-        get submissions_phase_path(phase, format: :json, page: 2)
+      it 'returns next page of submissions via partial' do
+        get submissions_phase_path(phase, page: 2, partial: true)
         expect(response).to have_http_status(:success)
         expect(response.body).to have_css('tr[data-submission-id]', count: 5)
+        expect(response.body).not_to have_button('Load more')
       end
 
       context 'when sorting by average score' do
@@ -263,13 +265,14 @@ RSpec.describe "Submissions" do
         end
 
         it 'paginates correctly when sorted by score' do
-          get submissions_phase_path(phase, format: :json, page: 1, sort: 'average_score_high_to_low')
+          get submissions_phase_path(phase, page: 1, sort: 'average_score_high_to_low')
           expect(response).to have_http_status(:success)
           first_page_scores = response.body.scan(/data-score="(\d+)"/).flatten
           expect(first_page_scores.count).to eq(20)
           expect(first_page_scores.map(&:to_i)).to eq(first_page_scores.map(&:to_i).sort.reverse)
+          expect(response.body).to have_button('Load more')
 
-          get submissions_phase_path(phase, format: :json, page: 2, sort: 'average_score_high_to_low')
+          get submissions_phase_path(phase, page: 2, partial: true, sort: 'average_score_high_to_low')
           expect(response).to have_http_status(:success)
           second_page_scores = response.body.scan(/data-score="(\d+)"/).flatten
           expect(second_page_scores.count).to eq(5)
@@ -283,11 +286,12 @@ RSpec.describe "Submissions" do
         end
 
         it 'paginates correctly with eligible filter' do
-          get submissions_phase_path(phase, format: :json, page: 1, eligible_for_evaluation: 'true')
+          get submissions_phase_path(phase, page: 1, eligible_for_evaluation: 'true')
           expect(response).to have_http_status(:success)
           expect(response.body.scan(/data-submission-id="(\d+)"/).flatten.count).to eq(20)
+          expect(response.body).to have_button('Load more')
 
-          get submissions_phase_path(phase, format: :json, page: 2, eligible_for_evaluation: 'true')
+          get submissions_phase_path(phase, page: 2, partial: true, eligible_for_evaluation: 'true')
           expect(response).to have_http_status(:success)
           expect(response.body.scan(/data-submission-id="(\d+)"/).flatten.count).to eq(3)
         end

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -233,5 +233,65 @@ RSpec.describe "Submissions" do
         end
       end
     end
+
+    context 'when paginating submissions' do
+      let!(:submissions) do
+        (1..25).map do |n|
+          create(:submission, challenge: challenge, phase: phase)
+        end
+      end
+
+      it 'returns first page of submissions' do
+        get submissions_phase_path(phase)
+        expect(response.body).to have_css('tr[data-submission-id]', count: 20)
+      end
+
+      it 'returns next page of submissions via JSON' do
+        get submissions_phase_path(phase, format: :json, page: 2)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to have_css('tr[data-submission-id]', count: 5)
+      end
+
+      context 'when sorting by average score' do
+        let!(:scored_submissions) do
+          submissions[0..24].each_with_index do |submission, index|
+            create(:evaluation,
+              evaluator_submission_assignment: create(:evaluator_submission_assignment, submission: submission),
+              total_score: (index + 1) * 20
+            )
+          end
+        end
+
+        it 'paginates correctly when sorted by score' do
+          get submissions_phase_path(phase, format: :json, page: 1, sort: 'average_score_high_to_low')
+          expect(response).to have_http_status(:success)
+          first_page_scores = response.body.scan(/data-score="(\d+)"/).flatten
+          expect(first_page_scores.count).to eq(20)
+          expect(first_page_scores.map(&:to_i)).to eq(first_page_scores.map(&:to_i).sort.reverse)
+
+          get submissions_phase_path(phase, format: :json, page: 2, sort: 'average_score_high_to_low')
+          expect(response).to have_http_status(:success)
+          second_page_scores = response.body.scan(/data-score="(\d+)"/).flatten
+          expect(second_page_scores.count).to eq(5)
+          expect(second_page_scores.map(&:to_i)).to eq(second_page_scores.map(&:to_i).sort.reverse)
+        end
+      end
+
+      context 'when filtering submissions' do
+        let!(:eligible_submissions) do
+          submissions[0..22].each { |s| s.update!(judging_status: 'selected') }
+        end
+
+        it 'paginates correctly with eligible filter' do
+          get submissions_phase_path(phase, format: :json, page: 1, eligible_for_evaluation: 'true')
+          expect(response).to have_http_status(:success)
+          expect(response.body.scan(/data-submission-id="(\d+)"/).flatten.count).to eq(20)
+
+          get submissions_phase_path(phase, format: :json, page: 2, eligible_for_evaluation: 'true')
+          expect(response).to have_http_status(:success)
+          expect(response.body.scan(/data-submission-id="(\d+)"/).flatten.count).to eq(3)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Related ticket: #293 

Limit the initial data load of submissions and add a **Load more** button below the list to view more submissions. Data is _paginated_ on the Rails backend

This feature depended on the completion of #207 & #57 (Sort & Filter). 

<img width="930" alt="Screenshot 2024-12-30 at 6 22 14 PM" src="https://github.com/user-attachments/assets/94a9c0cc-5121-44af-85a1-8a2f64f4c897" />

#### Tablet & Mobile
<img width="667" alt="Screenshot 2024-12-30 at 6 29 32 PM" src="https://github.com/user-attachments/assets/6b3eb7d8-9364-4a6d-a4a3-19763807d0fb" />
<img width="273" alt="Screenshot 2024-12-30 at 6 22 33 PM" src="https://github.com/user-attachments/assets/325f200a-39b6-4277-aa18-b2144b5302f1" />

#### WAVE
<img width="730" alt="Screenshot 2024-12-30 at 6 23 06 PM" src="https://github.com/user-attachments/assets/bde479ec-5bda-464d-a525-2f19b4ea7bfe" />
<img width="1042" alt="Screenshot 2024-12-30 at 6 23 19 PM" src="https://github.com/user-attachments/assets/fb19f8c9-ba43-466a-bb67-253f5c892143" />

#### Interaction with Sort & Filter
![load_more_submissions](https://github.com/user-attachments/assets/0a9dd0b2-2046-44c5-b1f5-54188ea9071f)

