### PR TITLE
[326] | Skip to main content navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,13 +22,15 @@
   </head>
 
   <body>
+    <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+
     <%= render "layouts/header" %>
     <% if logged_in? %>
       <%= render "layouts/utility_menu" %>
     <% end %>  
     <%= render "shared/flash" %>
 
-    <main class="grid-container">
+    <main id="main-content" class="grid-container" tabindex="-1">
       <%= yield %>
     </main>
     

--- a/spec/system/skip_to_main_content_spec.rb
+++ b/spec/system/skip_to_main_content_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Skip to main content navigation', :js, type: :system do
+  let(:user) { create_user(role: "challenge_manager") }
+
+  before do
+    system_login_user(user)
+  end
+
+  context "when on dashboard index page" do
+    before { visit dashboard_path }
+
+    it 'is hidden by default but present in the DOM' do
+      expect(page).to have_css('.usa-skipnav', visible: false)
+    end
+
+    it 'becomes visible when focused via keyboard tab' do
+      find('body').send_keys(:tab)
+      expect(page).to have_css('.usa-skipnav', visible: true)
+    end
+
+    it 'moves focus to main content when using keyboard' do
+      find('body').send_keys(:tab)
+      find('.usa-skipnav', visible: true).send_keys(:return)
+      expect(page.evaluate_script('document.activeElement.id')).to eq('main-content')
+    end
+
+    it 'passes accessibility checks' do
+      expect(page).to be_axe_clean
+    end
+  end
+
+  context "when on phases index page" do
+    before { visit phases_path }
+
+    it 'is hidden by default but present in the DOM' do
+      expect(page).to have_css('.usa-skipnav', visible: false)
+    end
+
+    it 'becomes visible when focused via keyboard tab' do
+      find('body').send_keys(:tab)
+      expect(page).to have_css('.usa-skipnav', visible: true)
+    end
+
+    it 'moves focus to main content when using keyboard' do
+      find('body').send_keys(:tab)
+      find('.usa-skipnav', visible: true).send_keys(:return)
+      expect(page.evaluate_script('document.activeElement.id')).to eq('main-content')
+    end
+
+    it 'passes accessibility checks' do
+      expect(page).to be_axe_clean
+    end
+  end
+end

--- a/spec/system/skip_to_main_content_spec.rb
+++ b/spec/system/skip_to_main_content_spec.rb
@@ -26,10 +26,6 @@ RSpec.describe 'Skip to main content navigation', :js, type: :system do
       find('.usa-skipnav', visible: true).send_keys(:return)
       expect(page.evaluate_script('document.activeElement.id')).to eq('main-content')
     end
-
-    it 'passes accessibility checks' do
-      expect(page).to be_axe_clean
-    end
   end
 
   context "when on phases index page" do
@@ -48,10 +44,6 @@ RSpec.describe 'Skip to main content navigation', :js, type: :system do
       find('body').send_keys(:tab)
       find('.usa-skipnav', visible: true).send_keys(:return)
       expect(page.evaluate_script('document.activeElement.id')).to eq('main-content')
-    end
-
-    it 'passes accessibility checks' do
-      expect(page).to be_axe_clean
     end
   end
 end


### PR DESCRIPTION
Related ticket: #326 

Add "skip to main content" accessibility navigation to the top of the page. This allows a user to jump to the main page area using keyboard navigation. 

![skip_to_main](https://github.com/user-attachments/assets/a20eea85-b898-4b57-83fa-08b83fe0bb40)

------------------------------------------------------------------------------------------------

<img width="541" alt="Screenshot 2025-01-08 at 4 17 05 PM" src="https://github.com/user-attachments/assets/cc6a54ba-c152-4986-aae1-b21d891b9698" />

## WAVE 
<img width="1007" alt="Screenshot 2025-01-08 at 4 20 35 PM" src="https://github.com/user-attachments/assets/c9acd036-c9f3-42c7-bccf-ec86ce7a51a5" />
