### PR TITLE
remove unnecessary association that is breaking things

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -33,7 +33,6 @@ class Submission < ApplicationRecord
   belongs_to :challenge
   belongs_to :phase, counter_cache: true
   belongs_to :submitter, class_name: 'User'
-  belongs_to :manager, class_name: 'User'
   has_many :evaluator_submission_assignments, dependent: :destroy
   has_many :evaluators, through: :evaluator_submission_assignments, class_name: "User"
   has_many :evaluations, dependent: :destroy

--- a/app/views/phases/_submissions_stats.html.erb
+++ b/app/views/phases/_submissions_stats.html.erb
@@ -11,9 +11,9 @@
                 <span class="font-sans-3xl text-primary text-bold"><%= @submissions_count %></span>
             </div>
             <div>
-                <h3 class="usa-summary-box__heading text-primary margin-bottom-05" id="summary-box-key-information">
+                <h2 class="usa-summary-box__heading text-primary margin-bottom-05" id="summary-box-key-information">
                 Total Submissions
-                </h3>
+                </h2>
                 <p class="usa-summary-box__text text-primary-darker text-bold">
                 Evaluations due by <%= @phase.evaluation_form&.closing_date&.strftime('%m/%d/%Y') || "N/A" %>
                 </p>
@@ -26,15 +26,15 @@
         <div class="display-flex flex-row tablet:margin-left-auto">
             <div class="text-center margin-right-5">
             <span class="font-sans-xl text-green text-bold"><%= @submissions_by_status[:completed] || 0 %></span><br>
-            <span class="text-base-sm text-green text-bold">Completed</span>
+            <span class="font-sans-lg text-green text-bold">Completed</span>
             </div>
             <div class="text-center margin-right-5">
-            <span class="font-sans-xl text-orange text-bold"><%= @submissions_by_status[:in_progress] || 0 %></span><br>
-            <span class="text-base-sm text-orange text-bold">In Progress</span>
+            <span class="font-sans-xl text-accent-warm-dark  text-bold"><%= @submissions_by_status[:in_progress] || 0 %></span><br>
+            <span class="font-sans-lg text-accent-warm-dark text-bold">In Progress</span>
             </div>
             <div class="text-center margin-right-2">
             <span class="font-sans-xl text-secondary-dark text-bold"><%= @submissions_by_status[:not_started] || 0 %></span><br>
-            <span class="text-base-sm text-secondary-dark text-bold">Not Started</span>
+            <span class="font-sans-lg text-secondary-dark text-bold">Not Started</span>
             </div>
         </div>
         </div>

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     association :challenge
     association :phase
     association :submitter, factory: :user
-    association :manager, factory: :user
 
     title { Faker::Lorem.sentence }
     status { "draft" }

--- a/spec/models/evaluation_spec.rb
+++ b/spec/models/evaluation_spec.rb
@@ -18,7 +18,7 @@ require 'rails_helper'
 
 RSpec.describe Evaluation, type: :model do
   let(:user) { create(:user, :evaluator) }
-  let(:submission) { create(:submission, manager: user) }
+  let(:submission) { create(:submission) }
   let(:evaluator_submission_assignment) { create(:evaluator_submission_assignment, evaluator: user) }
   let(:evaluation_form) { create(:evaluation_form) }
   let(:evaluation) { create(:evaluation, user:, evaluation_form:, submission:, evaluator_submission_assignment:) }

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "Submissions" do
           get submissions_phase_path(phase)
           expect(response.body).to include("Boston Tea Party Cleanup")
           # total submission count
-          expect(response.body).to have_css("h3.text-primary", text: "Total Submissions")
+          expect(response.body).to have_css("h2.text-primary", text: "Total Submissions")
           expect(response.body).to have_css("span.font-sans-3xl.text-primary.text-bold", text: "2")
           # selected to advance
           expect(response.body).to have_css("span.text-primary", text: "1 of 2")
@@ -229,9 +229,9 @@ RSpec.describe "Submissions" do
             expect(response.body).to have_css("[data-submission-id='#{submission.id}']")
           end
 
-          expect(response.body).to have_css('.text-secondary-dark.text-bold', text: '2')  # not_started, eligible
-          expect(response.body).to have_css('.text-orange.text-bold', text: '1')          # in_progress
-          expect(response.body).to have_css('.text-green.text-bold', text: '2')           # completed, selected
+          expect(response.body).to have_css('.text-secondary-dark.text-bold', text: '2')   # not_started, eligible
+          expect(response.body).to have_css('.text-accent-warm-dark.text-bold', text: '1') # in_progress
+          expect(response.body).to have_css('.text-green.text-bold', text: '2')            # completed, selected
         end
 
         context 'when filtering submissions' do

--- a/spec/system/submission_details_spec.rb
+++ b/spec/system/submission_details_spec.rb
@@ -7,7 +7,7 @@ describe "A11y", :js do
     let(:user) { create_user(role: "challenge_manager") }
     let(:challenge) { create_challenge(user: user, title: "Boston Tea Party Cleanup") }
     let(:phase) { create(:phase, challenge: challenge) }
-    let(:submission) { create(:submission, challenge:, phase:, manager: user, status: "submitted") }
+    let(:submission) { create(:submission, challenge:, phase:, status: "submitted") }
     let(:fake_comments) { Faker::Lorem.sentence }
 
     before do

--- a/spec/system/submissions_spec.rb
+++ b/spec/system/submissions_spec.rb
@@ -11,14 +11,14 @@ describe "A11y", :js do
     it "manage submissions by challenge phase page is accessible with one challenge" do
       challenge = create_challenge(user: user, title: "Boston Tea Party Cleanup")
       phase = create_phase(challenge_id: challenge.id)
-      create(:submission, manager: user, challenge: challenge, phase: phase)
+      create(:submission, challenge: challenge, phase: phase)
 
       visit submissions_phase_path(phase)
       expect(user.role).to eq("challenge_manager")
       expect(page).to have_content("Boston Tea Party Cleanup")
       expect(page).to have_content("Total Submissions")
       # commenting out for now, switch this back on soon
-      # expect(page).to(be_axe_clean)
+      expect(page).to(be_axe_clean)
     end
   end
 end


### PR DESCRIPTION
There is an issue with #292 where submissions with `manager_id: nil` can't be updated. However, this is not necessary and the association can be disregarded.
The issue discovered on staging prevented submissions from being marked eligible for evaluation because they were missing the "required" `belongs_to :manager`, which was not actually required.