### PR TITLE
[1508] modify migration to succeed if the column already exists

### DIFF
--- a/db/migrate/20241115193605_add_submissions_count_to_phases.rb
+++ b/db/migrate/20241115193605_add_submissions_count_to_phases.rb
@@ -1,5 +1,5 @@
 class AddSubmissionsCountToPhases < ActiveRecord::Migration[7.2]
   def change
-    add_column :phases, :submissions_count, :integer, default: 0, null: false
+    add_column :phases, :submissions_count, :integer, default: 0, null: false, if_not_exists: true
   end
 end


### PR DESCRIPTION
Related to #1508, this updates the existing Rails migration to make it optional if the migration already ran on the Phoenix app.

Based on the Rails API documentation - [add_column](https://api.rubyonrails.org/v8.0.1/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_column) options