### PR TITLE
[285] Adjust Challenge Phase index query for Evaluators

### DIFF
--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -10,12 +10,12 @@ class EvaluationsController < ApplicationController
   before_action :set_phase, only: [:submissions]
 
   def index
-    @challenges = Challenge.joins(phases: { submissions: :evaluator_submission_assignments }).
+    @phases = Phase.joins(:evaluator_submission_assignments).
       where(evaluator_submission_assignments: {
         user_id: current_user.id,
         status: [:assigned, :recused]
       }).
-      includes(phases: [:evaluation_form]).
+      includes(:challenge, :evaluation_form).
       distinct
   end
 

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -10,8 +10,11 @@ class EvaluationsController < ApplicationController
   before_action :set_phase, only: [:submissions]
 
   def index
-    @challenges = Challenge.joins(phases: :challenge_phases_evaluators).
-      where(challenge_phases_evaluators: { user_id: current_user.id }).
+    @challenges = Challenge.joins(phases: { submissions: :evaluator_submission_assignments }).
+      where(evaluator_submission_assignments: {
+        user_id: current_user.id,
+        status: [:assigned, :recused]
+      }).
       includes(phases: [:evaluation_form]).
       distinct
   end

--- a/app/views/evaluations/_phases_table.html.erb
+++ b/app/views/evaluations/_phases_table.html.erb
@@ -33,8 +33,6 @@
               View Submissions
             <% end %>
           </div>
-          </div>  
-        </td>
         </td>  
       </tr>
     <% end %>

--- a/app/views/evaluations/_phases_table.html.erb
+++ b/app/views/evaluations/_phases_table.html.erb
@@ -9,36 +9,34 @@
     </tr>
   </thead>
   <tbody>
-    <% @challenges.each do |challenge| %>
-      <% challenge.phases.each do |phase| %>
-        <tr>
-          <th data-label="Challenge Title" scope="row" class="text-top">
-            <%= challenge_phase_title(challenge, phase) %>
-          </th>
-          <td data-label="Assigned to me" class="text-top">
-            <%= assigned_submissions_count(current_user, challenge, phase) %>
-          </td>
-          <td data-label="Remaining to evaluate" class="text-top">
-            <%= remaining_evaluations_count(current_user, challenge, phase) %>
-          </td>
-          <td data-label="Due by" class="text-top">
-            <% if phase.evaluation_form %>
-              <%= phase.evaluation_form.closing_date %>
-            <% else %>
-              N/A
+    <% @phases.each do |phase| %>
+      <tr>
+        <th data-label="Challenge Title" scope="row" class="text-top">
+          <%= challenge_phase_title(phase.challenge, phase) %>
+        </th>
+        <td data-label="Assigned to me" class="text-top">
+          <%= assigned_submissions_count(current_user, phase.challenge, phase) %>
+        </td>
+        <td data-label="Remaining to evaluate" class="text-top">
+          <%= remaining_evaluations_count(current_user, phase.challenge, phase) %>
+        </td>
+        <td data-label="Due by" class="text-top">
+          <% if phase.evaluation_form %>
+            <%= phase.evaluation_form.closing_date %>
+          <% else %>
+            N/A
+          <% end %>
+        </td>
+        <td>
+          <div class="display-flex flex-column grid-row grid-gap-1 padding-bottom-2">
+            <%= link_to submissions_evaluation_path(phase), class: "usa-button font-body-2xs text-no-wrap width-full" do %>
+              View Submissions
             <% end %>
-          </td>
-          <td>
-            <div class="display-flex flex-column grid-row grid-gap-1 padding-bottom-2">
-              <%= link_to submissions_evaluation_path(phase), class: "usa-button font-body-2xs text-no-wrap width-full" do %>
-                View Submissions
-              <% end %>
-            </div>
-            </div>  
-          </td>
-          </td>  
-        </tr>
-      <% end %>  
-    <% end %>  
+          </div>
+          </div>  
+        </td>
+        </td>  
+      </tr>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/evaluations/index.html.erb
+++ b/app/views/evaluations/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Evaluations</h1>
 <p class="text-normal padding-bottom-2">View challenges with submissions assigned to me to evaluate.</p>
 
-<% if @challenges.empty? %>
+<% if @phases.empty? %>
   <div class="text-normal">
     <p>You currently do not have any challenges.</p>
   </div>

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -65,38 +65,56 @@ RSpec.describe "Evaluations" do
 
     context "when logged in as an evaluator" do
       let(:evaluator) { create_and_log_in_user(role: 'evaluator') }
-      let(:challenge) { create(:challenge) }
-      let(:phase) { create(:phase, challenge: challenge) }
+
+      let(:challenge) { create(:challenge, title: "Challenge with Assignments", is_multi_phase: false) }
+      let(:phase) { challenge.phases.first }
+
+      let(:other_challenge) { create(:challenge, title: "Challenge without Assignments", is_multi_phase: false) }
+      let(:other_phase) { other_challenge.phases.first }
 
       before do
-        ChallengePhasesEvaluator.create!(
-          challenge: challenge,
-          phase: phase,
-          user: evaluator
-        )
+        ChallengePhasesEvaluator.create!(challenge: challenge, phase: phase, user: evaluator)
+        ChallengePhasesEvaluator.create!(challenge: other_challenge, phase: other_phase, user: evaluator)
       end
 
-      it "only shows challenges with assigned submissions" do
-        submission = create(:submission, phase: phase)
+      it "only shows challenges with assigned or recused submissions" do
+        assigned_submission = create(:submission, phase: phase, challenge: challenge)
         create(:evaluator_submission_assignment,
-          submission: submission,
+          submission: assigned_submission,
           evaluator: evaluator,
           status: :assigned
         )
 
-        # Create another challenge/phase where evaluator is added but has no assignments
-        other_challenge = create(:challenge)
-        other_phase = create(:phase, challenge: other_challenge)
-        ChallengePhasesEvaluator.create!(
-          challenge: other_challenge,
-          phase: other_phase,
-          user: evaluator
+        recused_submission = create(:submission, phase: phase, challenge: challenge)
+        create(:evaluator_submission_assignment,
+          submission: recused_submission,
+          evaluator: evaluator,
+          status: :recused
+        )
+
+        unassigned_submission = create(:submission, phase: phase, challenge: challenge)
+        create(:evaluator_submission_assignment,
+          submission: unassigned_submission,
+          evaluator: evaluator,
+          status: :unassigned
+        )
+
+        recused_unassigned_submission = create(:submission, phase: phase, challenge: challenge)
+        create(:evaluator_submission_assignment,
+          submission: recused_unassigned_submission,
+          evaluator: evaluator,
+          status: :recused_unassigned
         )
 
         get evaluations_path
 
         expect(response.body).to include(challenge.title)
         expect(response.body).not_to include(other_challenge.title)
+        expect(response.body.scan(/data-label="Challenge Title"/).count).to eq(1)
+        expect(response.body).to have_css('td[data-label="Assigned to me"]')
+        expect(response.body).to have_css('td[data-label="Assigned to me"]', text: '2')
+        expect(response.body).to have_css('td[data-label="Remaining to evaluate"]')
+        expect(response.body).to have_css('td[data-label="Remaining to evaluate"]', text: '2')
       end
     end
   end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -62,6 +62,43 @@ RSpec.describe "Evaluations" do
         expect(response).to redirect_to(ENV.fetch("PHOENIX_URI", nil))
       end
     end
+
+    context "when logged in as an evaluator" do
+      let(:evaluator) { create_and_log_in_user(role: 'evaluator') }
+      let(:challenge) { create(:challenge) }
+      let(:phase) { create(:phase, challenge: challenge) }
+
+      before do
+        ChallengePhasesEvaluator.create!(
+          challenge: challenge,
+          phase: phase,
+          user: evaluator
+        )
+      end
+
+      it "only shows challenges with assigned submissions" do
+        submission = create(:submission, phase: phase)
+        create(:evaluator_submission_assignment,
+          submission: submission,
+          evaluator: evaluator,
+          status: :assigned
+        )
+
+        # Create another challenge/phase where evaluator is added but has no assignments
+        other_challenge = create(:challenge)
+        other_phase = create(:phase, challenge: other_challenge)
+        ChallengePhasesEvaluator.create!(
+          challenge: other_challenge,
+          phase: other_phase,
+          user: evaluator
+        )
+
+        get evaluations_path
+
+        expect(response.body).to include(challenge.title)
+        expect(response.body).not_to include(other_challenge.title)
+      end
+    end
   end
 
   describe "GET /evaluations/:id/submissions" do

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -66,55 +66,96 @@ RSpec.describe "Evaluations" do
     context "when logged in as an evaluator" do
       let(:evaluator) { create_and_log_in_user(role: 'evaluator') }
 
-      let(:challenge) { create(:challenge, title: "Challenge with Assignments", is_multi_phase: false) }
-      let(:phase) { challenge.phases.first }
+      let(:challenge_with_submissions) { create(:challenge, title: "Challenge with Submissions", is_multi_phase: false) }
+      let(:phase_with_submissions) { challenge_with_submissions.phases.first }
 
-      let(:other_challenge) { create(:challenge, title: "Challenge without Assignments", is_multi_phase: false) }
-      let(:other_phase) { other_challenge.phases.first }
+      let(:multi_phase_challenge) { create(:challenge, title: "Multi-Phase Challenge", is_multi_phase: true) }
+      let(:phase1) { create(:phase, challenge: multi_phase_challenge) }
+      let(:phase2) { create(:phase, challenge: multi_phase_challenge) }
+
+      let(:challenge_without_submissions) { create(:challenge, title: "Challenge without Submissions", is_multi_phase: false) }
+      let(:phase_without_submissions) { challenge_without_submissions.phases.first }
 
       before do
-        ChallengePhasesEvaluator.create!(challenge: challenge, phase: phase, user: evaluator)
-        ChallengePhasesEvaluator.create!(challenge: other_challenge, phase: other_phase, user: evaluator)
+        ChallengePhasesEvaluator.create!(challenge: challenge_with_submissions, phase: phase_with_submissions, user: evaluator)
+        ChallengePhasesEvaluator.create!(challenge: multi_phase_challenge, phase: phase1, user: evaluator)
+        ChallengePhasesEvaluator.create!(challenge: challenge_without_submissions, phase: phase_without_submissions, user: evaluator)
       end
 
-      it "only shows challenges with assigned or recused submissions" do
-        assigned_submission = create(:submission, phase: phase, challenge: challenge)
+      it "only shows phases with assigned or recused submissions" do
+        # Submissions for single phase challenge
+        assigned_submission = create(:submission, phase: phase_with_submissions, challenge: challenge_with_submissions)
         create(:evaluator_submission_assignment,
           submission: assigned_submission,
           evaluator: evaluator,
           status: :assigned
         )
 
-        recused_submission = create(:submission, phase: phase, challenge: challenge)
+        recused_submission = create(:submission, phase: phase_with_submissions, challenge: challenge_with_submissions)
         create(:evaluator_submission_assignment,
           submission: recused_submission,
           evaluator: evaluator,
           status: :recused
         )
 
-        unassigned_submission = create(:submission, phase: phase, challenge: challenge)
+        unassigned_submission = create(:submission, phase: phase_with_submissions, challenge: challenge_with_submissions)
         create(:evaluator_submission_assignment,
           submission: unassigned_submission,
           evaluator: evaluator,
           status: :unassigned
         )
 
-        recused_unassigned_submission = create(:submission, phase: phase, challenge: challenge)
+        recused_unassigned_submission = create(:submission, phase: phase_with_submissions, challenge: challenge_with_submissions)
         create(:evaluator_submission_assignment,
           submission: recused_unassigned_submission,
           evaluator: evaluator,
           status: :recused_unassigned
         )
 
+        # Submissions for multi-phase challenge
+        multi_phase_submission = create(:submission, phase: phase1, challenge: multi_phase_challenge)
+        create(:evaluator_submission_assignment,
+          submission: multi_phase_submission,
+          evaluator: evaluator,
+          status: :assigned
+        )
+
+        multi_phase_recused_submission = create(:submission, phase: phase1, challenge: multi_phase_challenge)
+        create(:evaluator_submission_assignment,
+          submission: multi_phase_recused_submission,
+          evaluator: evaluator,
+          status: :recused
+        )
+
+        multi_phase_unassigned_submission = create(:submission, phase: phase1, challenge: multi_phase_challenge)
+        create(:evaluator_submission_assignment,
+          submission: multi_phase_unassigned_submission,
+          evaluator: evaluator,
+          status: :unassigned
+        )
+
+        multi_phase_recused_unassigned_submission = create(:submission, phase: phase1, challenge: multi_phase_challenge)
+        create(:evaluator_submission_assignment,
+          submission: multi_phase_recused_unassigned_submission,
+          evaluator: evaluator,
+          status: :recused_unassigned
+        )
+
         get evaluations_path
 
-        expect(response.body).to include(challenge.title)
-        expect(response.body).not_to include(other_challenge.title)
-        expect(response.body.scan(/data-label="Challenge Title"/).count).to eq(1)
-        expect(response.body).to have_css('td[data-label="Assigned to me"]')
-        expect(response.body).to have_css('td[data-label="Assigned to me"]', text: '2')
-        expect(response.body).to have_css('td[data-label="Remaining to evaluate"]')
-        expect(response.body).to have_css('td[data-label="Remaining to evaluate"]', text: '2')
+        expect(response.body).to include(challenge_with_submissions.title)
+        expect(response.body).not_to include(challenge_without_submissions.title)
+
+        expect(response.body.scan(/data-label="Challenge Title"/).count).to eq(2)
+        expect(response.body.scan(/#{multi_phase_challenge.title}/).count).to eq(1)
+
+        within("#phase_#{phase_with_submissions.id}") do
+          expect(page).to have_css('td[data-label="Assigned to me"]', text: '2')
+        end
+
+        within("#phase_#{phase1.id}") do
+          expect(page).to have_css('td[data-label="Assigned to me"]', text: '2')
+        end
       end
     end
   end


### PR DESCRIPTION
Related ticket: #285 

The list of challenges should only show the challenges that the evaluator has assigned submissions to.

<img width="849" alt="Screenshot 2025-01-14 at 7 24 00 PM" src="https://github.com/user-attachments/assets/e1c5b771-9a91-4d8e-911d-135cfcab2cc2" />
<img width="1254" alt="Screenshot 2025-01-14 at 7 24 23 PM" src="https://github.com/user-attachments/assets/166094be-7183-41f4-b174-cf9495860180" />
