### PR TITLE
[88] Fix Screenreader A11y Error - Stats

### DIFF
--- a/app/views/phases/_submissions_stats.html.erb
+++ b/app/views/phases/_submissions_stats.html.erb
@@ -25,15 +25,15 @@
 
         <div class="display-flex flex-row tablet:margin-left-auto">
             <div class="text-center margin-right-5">
-            <span class="font-sans-xl text-green text-bold"><%= @submissions_by_status[:completed] || 0 %></span><br>
+            <span class="font-sans-xl text-green text-bold display-block"><%= @submissions_by_status[:completed] || 0 %></span>
             <span class="font-sans-lg text-green text-bold">Completed</span>
             </div>
             <div class="text-center margin-right-5">
-            <span class="font-sans-xl text-accent-warm-dark  text-bold"><%= @submissions_by_status[:in_progress] || 0 %></span><br>
+            <span class="font-sans-xl text-accent-warm-dark text-bold display-block"><%= @submissions_by_status[:in_progress] || 0 %></span>
             <span class="font-sans-lg text-accent-warm-dark text-bold">In Progress</span>
             </div>
             <div class="text-center margin-right-2">
-            <span class="font-sans-xl text-secondary-dark text-bold"><%= @submissions_by_status[:not_started] || 0 %></span><br>
+            <span class="font-sans-xl text-secondary-dark text-bold display-block"><%= @submissions_by_status[:not_started] || 0 %></span>
             <span class="font-sans-lg text-secondary-dark text-bold">Not Started</span>
             </div>
         </div>

--- a/app/views/shared/_assignment_stats.html.erb
+++ b/app/views/shared/_assignment_stats.html.erb
@@ -25,15 +25,15 @@
 
       <div class="display-flex flex-row tablet:margin-left-auto">
         <div class="text-center margin-right-1 margin-left-neg-1 tablet:margin-right-5">
-          <span class="font-sans-xl text-success-dark text-bold"><%= @submissions_count["completed"] || 0 %></span><br>
+          <span class="font-sans-xl text-success-dark text-bold display-block"><%= @submissions_count["completed"] || 0 %></span>
           <span class="font-sans-lg text-success-dark text-bold">Completed</span>
         </div>
         <div class="text-center margin-right-1 tablet:margin-right-4">
-          <span class="font-sans-xl text-accent-warm-dark text-bold"><%= @submissions_count["in_progress"] || 0 %></span><br>
+          <span class="font-sans-xl text-accent-warm-dark text-bold display-block"><%= @submissions_count["in_progress"] || 0 %></span>
           <span class="font-sans-lg text-accent-warm-dark text-bold">In Progress</span>
         </div>
         <div class="text-center margin-right-1 tablet:margin-right-2">
-          <span class="font-sans-xl text-error-dark text-bold"><%= @submissions_count["not_started"] || 0 %></span><br>
+          <span class="font-sans-xl text-error-dark text-bold display-block"><%= @submissions_count["not_started"] || 0 %></span>
           <span class="font-sans-lg text-error-dark text-bold">Not Started</span>
         </div>
       </div>

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -224,9 +224,9 @@ RSpec.describe "Evaluations" do
           expect(response.body).to include("In Progress")
           expect(response.body).to include("Not Started")
 
-          expect(response.body).to include('<span class="font-sans-xl text-success-dark text-bold">1</span>')
-          expect(response.body).to include('<span class="font-sans-xl text-accent-warm-dark text-bold">1</span>')
-          expect(response.body).to include('<span class="font-sans-xl text-error-dark text-bold">1</span>')
+          expect(response.body).to include('<span class="font-sans-xl text-success-dark text-bold display-block">1</span>')
+          expect(response.body).to include('<span class="font-sans-xl text-accent-warm-dark text-bold display-block">1</span>')
+          expect(response.body).to include('<span class="font-sans-xl text-error-dark text-bold display-block">1</span>')
         end
       end
 


### PR DESCRIPTION
Related ticket: #88 

Fix screenreader a11y error on both the challenge manager submission stats and evaluator assignment stats components. 

<img width="948" alt="Screenshot 2025-01-15 at 6 18 07 PM" src="https://github.com/user-attachments/assets/2b13764f-a193-459a-9677-95d6a6ca0a34" />
