### PR TITLE
[345] Evaluation Status

### DIFF
--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -1,5 +1,7 @@
 <% if @submission.evaluator_submission_assignments.recused.exists? %>
-  <%= render 'shared/alert_error', alert_heading: t('alerts.recused_evaluator.heading'), alert_text: t('alerts.recused_evaluator_submission.text') %>
+  <div class="margin-bottom-2">
+    <%= render 'shared/alert_error', alert_heading: t('alerts.recused_evaluator.heading'), alert_text: t('alerts.recused_evaluator_submission.text') %>
+  </div>
 <% end %>
 
 <div class="usa-accordion">
@@ -15,7 +17,7 @@
     </button>
   </h2>
 
-  <div class="usa-accordion__content" id="<%= rand %>">
+  <div class="usa-accordion__content overflow-hidden" id="<%= rand %>">
     <% assigned_evaluators = @submission.evaluators.where("evaluator_submission_assignments.status" => ["assigned", "recused"]) %>
       <% if assigned_evaluators.any? %>
         <table class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
@@ -46,10 +48,10 @@
                     <span class="margin-x-1"><%= evaluator_score(assignment).formatted_score %></span>
                   </td>
                   <td data-label="">
-                    <div class="display-flex flex-no-wrap grid-row">
+                    <div class="display-flex flex-wrap">
                       <% if assignment&.evaluation&.completed_at %>
-                        <%= link_to(evaluation_path(evaluation)) do %>
-                          <button class="usa-button font-body-2xs text-no-wrap">
+                        <%= link_to(evaluation_path(assignment.evaluation)) do %>
+                          <button class="usa-button font-body-3xs text-no-wrap padding-x-1 margin-bottom-1">
                             View Evaluation
                           </button>
                         <% end %>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -1,3 +1,7 @@
+<% if @submission.evaluator_submission_assignments.recused.exists? %>
+  <%= render 'shared/alert_error', alert_heading: t('alerts.recused_evaluator.heading'), alert_text: t('alerts.recused_evaluator_submission.text') %>
+<% end %>
+
 <div class="usa-accordion">
   <% rand = SecureRandom.hex(8) %>
   <h2 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
@@ -28,6 +32,9 @@
                 <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
                 <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
                   <th scope="row" data-label="Evaluator name" class="text-top">
+                    <% if assignment.status == "recused" %>
+                      <%= image_tag('images/usa-icons/error.svg', class: "usa-icon--size-3", alt: "Recused", style: "vertical-align: middle; margin-right: 5px;") %>
+                    <% end %>
                     <span class="text-bold text-ls-1 line-height-sans-4"><%= "#{evaluator.first_name} #{evaluator.last_name}" %></span>
                   </th>
                   <td data-label="Evaluation Status" class="text-top">

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -25,15 +25,21 @@
             </thead>
             <tbody>
               <% assigned_evaluators.each do |evaluator| %>
+                <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
                 <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
                   <th scope="row" data-label="Evaluator name" class="text-top">
                     <span class="text-bold text-ls-1 line-height-sans-4"><%= "#{evaluator.first_name} #{evaluator.last_name}" %></span>
                   </th>
-                  <td data-label="Evaluation Status" class="text-top"></td>
-                  <td data-label="Score" class="text-top"></td>
+                  <td data-label="Evaluation Status" class="text-top">
+                    <span class="usa-tag padding-x-1 display-inline-block <%= evaluation_submission_assignment_status_color(assignment) %>">
+                    <%= assignment.evaluation_status.to_s.titleize %>
+                </span>
+                  </td>
+                  <td data-label="Score" class="text-top">
+                    <span class="margin-x-1"><%= evaluator_score(assignment).formatted_score %></span>
+                  </td>
                   <td data-label="">
                     <div class="display-flex flex-no-wrap grid-row">
-                      <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
                       <%= form_with url: phase_evaluator_submission_assignment_path(@submission.phase, assignment.id), method: "PATCH" do |f| %>
                         <%= f.hidden_field :phase_id, value: @submission.phase.id %>
                         <%= f.hidden_field :status, value: assignment.recused? ? "recused_unassigned" : "unassigned" %>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -47,6 +47,13 @@
                   </td>
                   <td data-label="">
                     <div class="display-flex flex-no-wrap grid-row">
+                      <% if assignment&.evaluation&.completed_at %>
+                        <%= link_to(evaluation_path(evaluation)) do %>
+                          <button class="usa-button font-body-2xs text-no-wrap">
+                            View Evaluation
+                          </button>
+                        <% end %>
+                      <% end %>
                       <%= form_with url: phase_evaluator_submission_assignment_path(@submission.phase, assignment.id), method: "PATCH" do |f| %>
                         <%= f.hidden_field :phase_id, value: @submission.phase.id %>
                         <%= f.hidden_field :status, value: assignment.recused? ? "recused_unassigned" : "unassigned" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,3 +109,6 @@ en:
     recused_submission:
       heading: "Recused"
       text: "A user recused from evaluations for one of the challenge submissions. Please review the list of submissions and unassign a recused evaluator."
+    recused_evaluator_submission:
+      heading: "Recused Evaluator"
+      text: "This submission has a recused evaluator. Please unassign a recused evaluator."       


### PR DESCRIPTION
Adds evaluation status display to the assigned evaluators section of the submission details page. 

Also adds an alert if there is a recused evaluator assigned and an error icon next to that evaluator's name. 

Finally, adds a link to the evaluation if that evaluation is complete. 

<img width="923" alt="Screen Shot 2025-01-16 at 10 18 51 AM" src="https://github.com/user-attachments/assets/24a7ab02-1c3c-4c72-869c-2459298647ff" />
