### PR TITLE
[368] Add table names (a11y)

### DIFF
--- a/app/views/evaluations/_phases_table.html.erb
+++ b/app/views/evaluations/_phases_table.html.erb
@@ -5,7 +5,7 @@
       <th scope="col">Assigned to me</th>
       <th scope="col">Remaining to evaluate</th>
       <th scope="col">Due by</th>
-      <th scope="col" aria-label="Evaluate">&nbsp;</th>
+      <th scope="col"><span class="usa-sr-only">Evaluate</span></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/evaluations/_phases_table.html.erb
+++ b/app/views/evaluations/_phases_table.html.erb
@@ -5,7 +5,7 @@
       <th scope="col">Assigned to me</th>
       <th scope="col">Remaining to evaluate</th>
       <th scope="col">Due by</th>
-      <th scope="col" aria-label="Evaluate" aria-hidden="true">&nbsp;</th>
+      <th scope="col" aria-label="Evaluate">&nbsp;</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/evaluations/_phases_table.html.erb
+++ b/app/views/evaluations/_phases_table.html.erb
@@ -1,11 +1,11 @@
-<table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header margin-bottom-10">
+<table aria-label="List of Challenges" class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header margin-bottom-10">
   <thead>
     <tr>
       <th scope="col">Challenge</th>
       <th scope="col">Assigned to me</th>
       <th scope="col">Remaining to evaluate</th>
       <th scope="col">Due by</th>
-      <th scope="col"><span class="usa-sr-only">Evaluate</span></th>
+      <th scope="col" aria-label="Evaluate" aria-hidden="true">&nbsp;</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/evaluations/_submissions_table.html.erb
+++ b/app/views/evaluations/_submissions_table.html.erb
@@ -7,7 +7,7 @@
       <th scope="col">My evaluation status</th>
       <th scope="col">My score</th>
       <th scope="col">Average Score</th>
-      <th scope="col" aria-label="Evaluate">&nbsp;</th>
+      <th scope="col"><span class="usa-sr-only">Evaluate</span></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/evaluations/_submissions_table.html.erb
+++ b/app/views/evaluations/_submissions_table.html.erb
@@ -7,7 +7,7 @@
       <th scope="col">My evaluation status</th>
       <th scope="col">My score</th>
       <th scope="col">Average Score</th>
-      <th scope="col" aria-label="Evaluate" aria-hidden="true">&nbsp;</th>
+      <th scope="col" aria-label="Evaluate">&nbsp;</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/evaluations/_submissions_table.html.erb
+++ b/app/views/evaluations/_submissions_table.html.erb
@@ -1,13 +1,13 @@
 <%= render 'shared/assignment_stats', heading: 'Total Submissions' %>
 
-<table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header margin-bottom-10">
+<table aria-label="List of Submissions to Evaluate" class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header margin-bottom-10">
   <thead>
     <tr>
       <th scope="col">Submission ID</th>
       <th scope="col">My evaluation status</th>
       <th scope="col">My score</th>
       <th scope="col">Average Score</th>
-      <th scope="col"><span class="usa-sr-only">Evaluate</span></th>
+      <th scope="col" aria-label="Evaluate" aria-hidden="true">&nbsp;</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/evaluator_submission_assignments/_submission_table.html.erb
+++ b/app/views/evaluator_submission_assignments/_submission_table.html.erb
@@ -1,11 +1,11 @@
 <div class="usa-table-container--scrollable width-full margin-bottom-10" tabindex="0">
-  <table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
+  <table aria-label="List of the Evaluator's Submissions" class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
     <thead>
       <tr>
         <th scope="col">Submission ID</th>
         <th scope="col" class="text-black">Evaluation status</th>
         <th scope="col">Score</th>
-        <th scope="col" aria-label="Actions"></th>
+        <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/evaluator_submission_assignments/_submission_table.html.erb
+++ b/app/views/evaluator_submission_assignments/_submission_table.html.erb
@@ -5,7 +5,7 @@
         <th scope="col">Submission ID</th>
         <th scope="col" class="text-black">Evaluation status</th>
         <th scope="col">Score</th>
-        <th scope="col" aria-label="Actions">&nbsp;</th>
+        <th scope="col"><span class="usa-sr-only">Actions</span></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/evaluator_submission_assignments/_submission_table.html.erb
+++ b/app/views/evaluator_submission_assignments/_submission_table.html.erb
@@ -5,7 +5,7 @@
         <th scope="col">Submission ID</th>
         <th scope="col" class="text-black">Evaluation status</th>
         <th scope="col">Score</th>
-        <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
+        <th scope="col" aria-label="Actions">&nbsp;</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -89,7 +89,7 @@
               <th scope="col">User role</th>
               <th scope="col">User status</th>
               <th scope="col">Assigned submissions</th>
-              <th scope="col" aria-label="Actions">&nbsp;</th>
+              <th scope="col"><span class="usa-sr-only">Actions</span></th>
             </tr>
           </thead>
           <tbody>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -81,7 +81,7 @@
         <p>Review evaluators for this challenge phase and track their submissions assignments.</p>
       </div>
       <div class="margin-bottom-10" tabindex="0">
-        <table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
+        <table aria-label="List of Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
           <thead>
             <tr>
               <th scope="col">Evaluator name</th>
@@ -89,7 +89,7 @@
               <th scope="col">User role</th>
               <th scope="col">User status</th>
               <th scope="col">Assigned submissions</th>
-              <th scope="col" aria-label="Actions"></th>
+              <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
             </tr>
           </thead>
           <tbody>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -89,7 +89,7 @@
               <th scope="col">User role</th>
               <th scope="col">User status</th>
               <th scope="col">Assigned submissions</th>
-              <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
+              <th scope="col" aria-label="Actions">&nbsp;</th>
             </tr>
           </thead>
           <tbody>

--- a/app/views/phases/_phases_table.html.erb
+++ b/app/views/phases/_phases_table.html.erb
@@ -5,7 +5,7 @@
         <th scope="col">Number of Submissions</th>
         <th scope="col">Evaluation Form</th>
         <th scope="col">Evaluations are due by</th>
-        <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
+        <th scope="col"><span class="usa-sr-only">Actions</span></th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/phases/_phases_table.html.erb
+++ b/app/views/phases/_phases_table.html.erb
@@ -1,11 +1,11 @@
-<table class="usa-table usa-table--stacked-header usa-table--borderless gray-header margin-bottom-10">
+<table aria-label="List of Challenges" class="usa-table usa-table--stacked-header usa-table--borderless gray-header margin-bottom-10">
     <thead>
       <tr>
         <th scope="col">Challenge</th>
         <th scope="col">Number of Submissions</th>
         <th scope="col">Evaluation Form</th>
         <th scope="col">Evaluations are due by</th>
-        <th scope="col"><span class="usa-sr-only">Actions</span></th>
+        <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/phases/_submissions_table.html.erb
+++ b/app/views/phases/_submissions_table.html.erb
@@ -19,7 +19,7 @@
         <th scope="col" style="width: 15%">Selected to Advance</th>
         <th scope="col" style="width: 40%">Assigned Evaluators</th>
         <th scope="col" style="width: 10%">Average Score</th>
-        <th scope="col" style="width: 5%"><span class="usa-sr-only">View Submission</span>&nbsp;</th>
+        <th scope="col" style="width: 5%"><span class="usa-sr-only">View Submission</span></th>
       </tr>
     </thead>
     <tbody data-load-more-target="container">

--- a/app/views/phases/_submissions_table.html.erb
+++ b/app/views/phases/_submissions_table.html.erb
@@ -19,7 +19,7 @@
         <th scope="col" style="width: 15%">Selected to Advance</th>
         <th scope="col" style="width: 40%">Assigned Evaluators</th>
         <th scope="col" style="width: 10%">Average Score</th>
-        <th scope="col" aria-label="View Submission" style="width: 5%">&nbsp;</th>
+        <th scope="col" style="width: 5%"><span class="usa-sr-only">View Submission</span>&nbsp;</th>
       </tr>
     </thead>
     <tbody data-load-more-target="container">

--- a/app/views/phases/_submissions_table.html.erb
+++ b/app/views/phases/_submissions_table.html.erb
@@ -19,7 +19,7 @@
         <th scope="col" style="width: 15%">Selected to Advance</th>
         <th scope="col" style="width: 40%">Assigned Evaluators</th>
         <th scope="col" style="width: 10%">Average Score</th>
-        <th scope="col" aria-label="View Submission" aria-hidden="true" style="width: 5%">&nbsp;</th>
+        <th scope="col" aria-label="View Submission" style="width: 5%">&nbsp;</th>
       </tr>
     </thead>
     <tbody data-load-more-target="container">

--- a/app/views/phases/_submissions_table.html.erb
+++ b/app/views/phases/_submissions_table.html.erb
@@ -11,7 +11,7 @@
 <div data-controller="load-more"
      data-load-more-total-count-value="<%= @filtered_count %>">
 
-  <table class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
+  <table aria-label="List of Submissions" class="usa-table usa-table--stacked-header usa-table--borderless width-full gray-header">
     <thead>
       <tr>
         <th scope="col" style="width: 15%">Submission ID</th>
@@ -19,7 +19,7 @@
         <th scope="col" style="width: 15%">Selected to Advance</th>
         <th scope="col" style="width: 40%">Assigned Evaluators</th>
         <th scope="col" style="width: 10%">Average Score</th>
-        <th scope="col" style="width: 5%"><span class="usa-sr-only">View Submission</span></th>
+        <th scope="col" aria-label="View Submission" aria-hidden="true" style="width: 5%">&nbsp;</th>
       </tr>
     </thead>
     <tbody data-load-more-target="container">

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -20,13 +20,13 @@
   <div class="usa-accordion__content overflow-hidden" id="<%= rand %>">
     <% assigned_evaluators = @submission.evaluators.where("evaluator_submission_assignments.status" => ["assigned", "recused"]) %>
       <% if assigned_evaluators.any? %>
-        <table class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
+        <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
             <thead>
               <tr>
                 <th scope="col">Evaluator name</th>
                 <th scope="col">Evaluation Status</th>
                 <th scope="col">Score</th>
-                <th scope="col" aria-label="Actions"></th>
+                <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
               </tr>
             </thead>
             <tbody>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -26,7 +26,7 @@
                 <th scope="col">Evaluator name</th>
                 <th scope="col">Evaluation Status</th>
                 <th scope="col">Score</th>
-                <th scope="col" aria-label="Actions" aria-hidden="true">&nbsp;</th>
+                <th scope="col" aria-label="Actions">&nbsp;</th>
               </tr>
             </thead>
             <tbody>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -26,7 +26,7 @@
                 <th scope="col">Evaluator name</th>
                 <th scope="col">Evaluation Status</th>
                 <th scope="col">Score</th>
-                <th scope="col" aria-label="Actions">&nbsp;</th>
+                <th scope="col"><span class="usa-sr-only">Actions</span></th>
               </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
Linked ticket: #368 

Add table names for all tables - added `aria-label="Table Name Here"` to resolve this a11y failure

<img width="922" alt="Screenshot 2025-01-30 at 4 27 25 PM" src="https://github.com/user-attachments/assets/484f7bfa-3482-41a4-bd60-76cdfade4317" />
<img width="1150" alt="Screenshot 2025-01-30 at 4 27 56 PM" src="https://github.com/user-attachments/assets/514923f6-a0f7-49ec-9736-8968561155d2" />
<img width="1149" alt="Screenshot 2025-01-30 at 4 28 20 PM" src="https://github.com/user-attachments/assets/8d84af23-2f15-47dc-bebb-f4c4013f8ebe" />
<img width="1128" alt="Screenshot 2025-01-30 at 4 28 53 PM" src="https://github.com/user-attachments/assets/bde4e075-d3f6-4bc6-ab14-fb54351a240f" />
<img width="751" alt="Screenshot 2025-01-30 at 4 29 32 PM" src="https://github.com/user-attachments/assets/610efa58-2fcb-495b-b398-4420997565d4" />
<img width="927" alt="Screenshot 2025-01-30 at 4 26 53 PM" src="https://github.com/user-attachments/assets/45093f5d-e0a0-4cb8-bc09-6f8865846df9" />
<img width="925" alt="Screenshot 2025-01-30 at 4 26 28 PM" src="https://github.com/user-attachments/assets/b459b320-ddac-406f-a3f6-224215dd1efa" />
