### PR TITLE
[391] fixes a broken link on evaluator_submission_assignments page

### DIFF
--- a/app/views/evaluator_submission_assignments/_submission_row.html.erb
+++ b/app/views/evaluator_submission_assignments/_submission_row.html.erb
@@ -12,7 +12,7 @@
   <td data-label="">
     <div class="display-flex flex-justify-end">
       <% if assignment.evaluation_status == :completed %>
-        <%= link_to "View Evaluation", submissions_path(@challenge), class: 'usa-button font-body-3xs margin-right-1' %>
+        <%= link_to "View Evaluation", evaluation_path(assignment.evaluation), class: 'usa-button font-body-3xs margin-right-1' %>
       <% end %>
       <%= button_tag "Unassign", type: 'button', class: 'usa-button usa-button--outline font-body-3xs', data: { 
         action: "click->unassign-evaluator-submission-modal#open",

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,6 +11,7 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable        = true
     Bullet.bullet_logger = true
+    Bullet.rails_logger  = true
     Bullet.raise         = true # raise an error if n+1 query occurs
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,11 +85,11 @@ RSpec.configure do |config|
     FactoryBot.reload
   end
 
-  config.before(:each, bullet: :skip) do
-    Bullet.enable = false
+  config.before(:each, bullet: :dont_raise) do
+    Bullet.raise = false
   end
 
-  config.after(:each, bullet: :skip) do
-    Bullet.enable = true
+  config.after(:each, bullet: :dont_raise) do
+    Bullet.raise = true
   end
 end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -513,7 +513,7 @@ RSpec.describe "Evaluations" do
         expect(score_criteria_ids).to match_array(criteria_ids)
       end
 
-      it "redirects me if I try to view an evaluation I did not create", bullet: :skip do
+      it "redirects me if I try to view an evaluation I did not create", bullet: :dont_raise do
         user = create(:user, :evaluator)
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: user.id)
         evaluation_form = create(:evaluation_form, phase: evaluator_submission_assignment.phase)
@@ -539,7 +539,7 @@ RSpec.describe "Evaluations" do
       before { log_in_user(current_user) }
 
       it "allows me to save a draft of my existing evaluation to skip validations and not set completed_at",
-         bullet: :skip do
+         bullet: :dont_raise do
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: current_user.id)
         evaluation_form = create(:evaluation_form, phase: evaluator_submission_assignment.phase)
 
@@ -573,7 +573,7 @@ RSpec.describe "Evaluations" do
         expect(flash[:notice]).to include(I18n.t("evaluations.notices.saved_draft"))
       end
 
-      it "does not allow me to save a draft of an evaluation I did not create", bullet: :skip do
+      it "does not allow me to save a draft of an evaluation I did not create", bullet: :dont_raise do
         user = create(:user, :evaluator)
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: user.id)
         evaluation_form = create(:evaluation_form, phase: evaluator_submission_assignment.phase)
@@ -601,7 +601,7 @@ RSpec.describe "Evaluations" do
 
       before { log_in_user(current_user) }
 
-      it "allows me to mark my existing evaluation as complete", bullet: :skip do
+      it "allows me to mark my existing evaluation as complete", bullet: :dont_raise do
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: current_user.id)
         evaluation_form = create(:evaluation_form, phase: evaluator_submission_assignment.phase)
 
@@ -627,7 +627,7 @@ RSpec.describe "Evaluations" do
         expect(flash[:notice]).to include(I18n.t("evaluations.notices.marked_complete"))
       end
 
-      it "does not allow me to mark my existing evaluation as complete if it fails validations", bullet: :skip do
+      it "does not allow me to mark my existing evaluation as complete if it fails validations", bullet: :dont_raise do
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: current_user.id)
         evaluation_form = create(:evaluation_form, phase: evaluator_submission_assignment.phase)
 
@@ -657,7 +657,7 @@ RSpec.describe "Evaluations" do
         expect(assigns(:evaluation).errors).not_to be_empty
       end
 
-      it "does not allow me to mark an evaluation I did not create as complete", bullet: :skip do
+      it "does not allow me to mark an evaluation I did not create as complete", bullet: :dont_raise do
         user = create(:user, :evaluator)
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: user.id)
         evaluation_form = create(:evaluation_form, phase: evaluator_submission_assignment.phase)

--- a/spec/requests/evaluator_submission_assignments_spec.rb
+++ b/spec/requests/evaluator_submission_assignments_spec.rb
@@ -31,18 +31,35 @@ RSpec.describe EvaluatorSubmissionAssignmentsController, type: :request do
   end
 
   describe 'GET #index' do
-    it 'renders the index page successfully', bullet: :skip do
+    it 'renders the index page successfully', bullet: :dont_raise do
       get phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator.id)
       expect(response).to have_http_status(:success)
-      expect(response.body).to include(evaluator.first_name)
+      expect(response.body).to have_css("h2.text-primary", text: "Evaluator: #{evaluator.first_name}")
     end
 
-    it 'displays the correct counts for assigned submissions', bullet: :skip do
-      get phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator.id)
-      expect(response.body).to include('Assigned Submissions')
-      expect(response.body).to include(assigned_assignment.submission.id.to_s)
-      expect(response.body).to include(unassigned_assignment.submission.id.to_s)
+    it 'renders the index with completed evaluations', bullet: :dont_raise do
+        evaluation = create(
+          :evaluation,
+          user: evaluator,
+          evaluation_form: evaluation_form,
+          submission: assigned_assignment.submission,
+          evaluator_submission_assignment: assigned_assignment,
+          completed_at: Time.current
+        )
+
+        get phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator.id)
+        expect(response).to have_http_status(:success)
+        expect(response.body).to have_css("td[data-label='Evaluation status'] span.usa-tag.bg-success-dark", text: "Completed")
+        expect(response.body).to have_css("a[href='/evaluations/#{evaluation.id}']", text: "View Evaluation")
     end
+
+    it 'displays the correct counts for assigned submissions', bullet: :dont_raise do
+      get phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator.id)
+      expect(response.body).to have_css('h3', text: 'Assigned Submissions')
+      expect(response.body).to have_css("td[data-label='Submission ID']", text: assigned_assignment.submission.id.to_s)
+      expect(response.body).to have_css("td[data-label='Submission ID']", text: unassigned_assignment.submission.id.to_s)
+    end
+
   end
 
   describe 'PATCH #update' do

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe "Submissions" do
             expect(response.body).to have_no_css("[data-submission-id='#{completed_submission.id}']")
           end
 
-          it 'shows only completed submissions', bullet: :skip do
+          it 'shows only completed submissions', bullet: :dont_raise do
             get submissions_phase_path(phase), params: { status: 'completed' }
 
             expect(response.body).to have_css("[data-submission-id='#{completed_submission.id}']")
@@ -261,7 +261,7 @@ RSpec.describe "Submissions" do
         end
 
         context 'when filtering by eligibility' do
-          it 'displays only eligible for evaluation submissions', bullet: :skip do
+          it 'displays only eligible for evaluation submissions', bullet: :dont_raise do
             get submissions_phase_path(phase), params: { eligible_for_evaluation: 'true' }
 
             expect(response.body).to have_css("[data-submission-id='#{eligible_submission.id}']")
@@ -271,7 +271,7 @@ RSpec.describe "Submissions" do
             expect(response.body).to have_no_css("[data-submission-id='#{completed_submission.id}']")
           end
 
-          it 'displays only selected to advance submissions', bullet: :skip do
+          it 'displays only selected to advance submissions', bullet: :dont_raise do
             get submissions_phase_path(phase), params: { selected_to_advance: 'true' }
 
             expect(response.body).to have_css("[data-submission-id='#{selected_submission.id}']")
@@ -344,7 +344,7 @@ RSpec.describe "Submissions" do
             end
           end
 
-          it 'paginates correctly when sorted by score', bullet: :skip do
+          it 'paginates correctly when sorted by score', bullet: :dont_raise do
             get submissions_phase_path(phase, page: 1, sort: 'average_score_high_to_low')
             expect(response).to have_http_status(:success)
             first_page_scores = response.body.scan(/data-score="(\d+)"/).flatten

--- a/spec/system/evaluator_submission_assignment_spec.rb
+++ b/spec/system/evaluator_submission_assignment_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'Evaluator Submission Assignments', :js, type: :system do
     end
   end
 
-  it 'allows assigning a submission to an evaluator', bullet: :skip do
+  it 'allows assigning a submission to an evaluator', bullet: :dont_raise do
     unassigned_assignment = create(
       :evaluator_submission_assignment,
       submission: submission,


### PR DESCRIPTION
The route helper doesn't exist and throws an error on staging while testing submission assignments.
Also made some configuration changes to Bullet so it logs the unoptimized queries instead of disabling them.