### PR TITLE
[57] Update 'not_started' query

### DIFF
--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -50,7 +50,12 @@ class PhasesController < ApplicationController
 
   def set_submission_statuses
     @not_started = @submissions.left_joins(evaluator_submission_assignments: :evaluation).
-      where(evaluations: { id: nil }).distinct
+      where(evaluator_submission_assignments: { id: nil }).
+      or(
+      @submissions.left_joins(evaluator_submission_assignments: :evaluation)
+        .where(evaluator_submission_assignments: { status: [:assigned, :unassigned] })
+        .where(evaluations: { id: nil })
+      ).distinct
     @in_progress = @submissions.joins(evaluator_submission_assignments: :evaluation).
       where(evaluations: { completed_at: nil }).distinct
     @completed = @submissions.joins(evaluator_submission_assignments: :evaluation).

--- a/app/controllers/phases_controller.rb
+++ b/app/controllers/phases_controller.rb
@@ -49,23 +49,39 @@ class PhasesController < ApplicationController
   end
 
   def set_submission_statuses
-    @not_started = @submissions.left_joins(evaluator_submission_assignments: :evaluation).
-      where(evaluator_submission_assignments: { id: nil }).
-      or(
-      @submissions.left_joins(evaluator_submission_assignments: :evaluation)
-        .where(evaluator_submission_assignments: { status: [:assigned, :unassigned] })
-        .where(evaluations: { id: nil })
-      ).distinct
-    @in_progress = @submissions.joins(evaluator_submission_assignments: :evaluation).
-      where(evaluations: { completed_at: nil }).distinct
-    @completed = @submissions.joins(evaluator_submission_assignments: :evaluation).
-      where.not(evaluations: { completed_at: nil }).
-      where.not(id: @in_progress.select(:id)).distinct
+    set_status_queries
     @submissions_by_status = {
       not_started: @not_started.count,
       in_progress: @in_progress.count,
       completed: @completed.count
     }
+  end
+
+  def set_status_queries
+    @not_started = not_started_submissions
+    @in_progress = in_progress_submissions
+    @completed = completed_submissions
+  end
+
+  def not_started_submissions
+    @submissions.left_joins(evaluator_submission_assignments: :evaluation).
+      where(evaluator_submission_assignments: { id: nil }).
+      or(
+        @submissions.left_joins(evaluator_submission_assignments: :evaluation).
+          where(evaluator_submission_assignments: { status: [:assigned, :unassigned] }).
+          where(evaluations: { id: nil })
+      ).distinct
+  end
+
+  def in_progress_submissions
+    @submissions.joins(evaluator_submission_assignments: :evaluation).
+      where(evaluations: { completed_at: nil }).distinct
+  end
+
+  def completed_submissions
+    @submissions.joins(evaluator_submission_assignments: :evaluation).
+      where.not(evaluations: { completed_at: nil }).
+      where.not(id: @in_progress.select(:id)).distinct
   end
 
   def paginate_submissions(submissions)


### PR DESCRIPTION
Linked ticket: #57 

Updated the `not_started` query to:
- include submissions that do not have an `evaluator_submission_assignment` yet (brand new submissions)
- include only submissions that are assigned or unassigned 
- include evaluations that are nil (not started)

I suspect the error that Renata found while testing, i.e. a submission with a `completed` evaluation was filtered under `not_started`, had the submission include an evaluation in which the evaluator had been `recused_unassigned`. The `recused_unassigned` evaluator did not show up under the submission row, so the evaluation looked like it was only `assigned` and `completed`, which is incorrect for the `not_started` filter. 
