### PR TITLE
[342] Delete assignments and evaluations when an evaluator is deleted

### DIFF
--- a/app/services/evaluator_management_service.rb
+++ b/app/services/evaluator_management_service.rb
@@ -101,15 +101,17 @@ class EvaluatorManagementService
   end
 
   def remove_user_evaluator(evaluator_id)
-    evaluator = User.find(evaluator_id)
-    cpe = ChallengePhasesEvaluator.find_by(challenge: @challenge, phase: @phase, user: evaluator)
-    if cpe.destroy
-      { success: true, message: I18n.t('evaluators.remove_user_evaluator.success') }
-    else
-      { success: false, message: I18n.t('evaluators.remove_user_evaluator.failure') }
+    ActiveRecord::Base.transaction do
+      evaluator = User.find(evaluator_id)
+      cpe = ChallengePhasesEvaluator.find_by(challenge: @challenge, phase: @phase, user: evaluator)
+
+      return evaluator_not_found_response unless cpe
+
+      delete_evaluator_assignments(evaluator)
+      delete_challenge_phase_evaluator(cpe)
     end
   rescue ActiveRecord::RecordNotFound
-    { success: false, message: I18n.t('evaluators.remove_user_evaluator.evaluator_not_found') }
+    evaluator_not_found_response
   rescue StandardError => e
     { success: false, message: "Error: #{e.message}" }
   end
@@ -125,5 +127,25 @@ class EvaluatorManagementService
     { success: false, message: I18n.t('evaluators.remove_evaluator_invitation.invitation_not_found') }
   rescue StandardError => e
     { success: false, message: "Error: #{e.message}" }
+  end
+
+  # deletes each evaluator submission assignment and its associated evaluation
+  def delete_evaluator_assignments(evaluator)
+    EvaluatorSubmissionAssignment.where(
+      user_id: evaluator.id,
+      submission_id: @phase.submissions.select(:id)
+    ).destroy_all
+  end
+
+  def delete_challenge_phase_evaluator(cpe)
+    if cpe.destroy
+      { success: true, message: I18n.t('evaluators.remove_user_evaluator.success') }
+    else
+      { success: false, message: I18n.t('evaluators.remove_user_evaluator.failure') }
+    end
+  end
+
+  def evaluator_not_found_response
+    { success: false, message: I18n.t('evaluators.remove_user_evaluator.evaluator_not_found') }
   end
 end

--- a/app/services/evaluator_management_service.rb
+++ b/app/services/evaluator_management_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# This service handles adding and removing evalutors to and from challenge phases.
+# This service handles inviting and adding evalutors to a challenge phase.
 class EvaluatorManagementService
   def initialize(challenge, phase)
     @challenge = challenge
@@ -15,14 +15,8 @@ class EvaluatorManagementService
   end
 
   def remove_evaluator(evaluator_type, evaluator_id)
-    case evaluator_type
-    when 'user'
-      remove_user_evaluator(evaluator_id)
-    when 'invitation'
-      remove_evaluator_invitation(evaluator_id)
-    else
-      { success: false, message: 'Invalid evaluator type' }
-    end
+    evaluator_removal_service = EvaluatorRemovalService.new(@challenge, @phase)
+    evaluator_removal_service.remove_evaluator(evaluator_type, evaluator_id)
   end
 
   def self.accept_evaluator_invitation(user)
@@ -98,54 +92,5 @@ class EvaluatorManagementService
     else
       { success: false, message: I18n.t('evaluators.process_evaluator_invitation.add_failure', email: user.email) }
     end
-  end
-
-  def remove_user_evaluator(evaluator_id)
-    ActiveRecord::Base.transaction do
-      evaluator = User.find(evaluator_id)
-      cpe = ChallengePhasesEvaluator.find_by(challenge: @challenge, phase: @phase, user: evaluator)
-
-      return evaluator_not_found_response unless cpe
-
-      delete_evaluator_assignments(evaluator)
-      delete_challenge_phase_evaluator(cpe)
-    end
-  rescue ActiveRecord::RecordNotFound
-    evaluator_not_found_response
-  rescue StandardError => e
-    { success: false, message: "Error: #{e.message}" }
-  end
-
-  def remove_evaluator_invitation(invitation_id)
-    invitation = @challenge.evaluator_invitations.find_by!(id: invitation_id, phase: @phase)
-    if invitation.destroy
-      { success: true, message: I18n.t('evaluators.remove_evaluator_invitation.success') }
-    else
-      { success: false, message: I18n.t('evaluators.remove_evaluator_invitation.failure') }
-    end
-  rescue ActiveRecord::RecordNotFound
-    { success: false, message: I18n.t('evaluators.remove_evaluator_invitation.invitation_not_found') }
-  rescue StandardError => e
-    { success: false, message: "Error: #{e.message}" }
-  end
-
-  # deletes each evaluator submission assignment and its associated evaluation
-  def delete_evaluator_assignments(evaluator)
-    EvaluatorSubmissionAssignment.where(
-      user_id: evaluator.id,
-      submission_id: @phase.submissions.select(:id)
-    ).destroy_all
-  end
-
-  def delete_challenge_phase_evaluator(cpe)
-    if cpe.destroy
-      { success: true, message: I18n.t('evaluators.remove_user_evaluator.success') }
-    else
-      { success: false, message: I18n.t('evaluators.remove_user_evaluator.failure') }
-    end
-  end
-
-  def evaluator_not_found_response
-    { success: false, message: I18n.t('evaluators.remove_user_evaluator.evaluator_not_found') }
   end
 end

--- a/app/services/evaluator_removal_service.rb
+++ b/app/services/evaluator_removal_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# This service handles removing evalutors and evaluator invitations from a challenge phase.
+class EvaluatorRemovalService
+  def initialize(challenge, phase)
+    @challenge = challenge
+    @phase = phase
+  end
+
+  def remove_evaluator(evaluator_type, evaluator_id)
+    case evaluator_type
+    when 'user'
+      remove_user_evaluator(evaluator_id)
+    when 'invitation'
+      remove_evaluator_invitation(evaluator_id)
+    else
+      { success: false, message: 'Invalid evaluator type' }
+    end
+  end
+
+  private
+
+  def remove_user_evaluator(evaluator_id)
+    ActiveRecord::Base.transaction do
+      evaluator = User.find(evaluator_id)
+      cpe = ChallengePhasesEvaluator.find_by(challenge: @challenge, phase: @phase, user: evaluator)
+
+      if cpe
+        delete_evaluator_assignments(evaluator)
+        delete_challenge_phase_evaluator(cpe)
+      else
+        next evaluator_not_found_response
+      end
+    end
+  rescue ActiveRecord::RecordNotFound
+    evaluator_not_found_response
+  rescue StandardError => e
+    { success: false, message: "Error: #{e.message}" }
+  end
+
+  def remove_evaluator_invitation(invitation_id)
+    invitation = @challenge.evaluator_invitations.find_by!(id: invitation_id, phase: @phase)
+    if invitation.destroy
+      { success: true, message: I18n.t('evaluators.remove_evaluator_invitation.success') }
+    else
+      { success: false, message: I18n.t('evaluators.remove_evaluator_invitation.failure') }
+    end
+  rescue ActiveRecord::RecordNotFound
+    { success: false, message: I18n.t('evaluators.remove_evaluator_invitation.invitation_not_found') }
+  rescue StandardError => e
+    { success: false, message: "Error: #{e.message}" }
+  end
+
+  # deletes each evaluator submission assignment and its associated evaluation
+  def delete_evaluator_assignments(evaluator)
+    EvaluatorSubmissionAssignment.where(
+      user_id: evaluator.id,
+      submission_id: @phase.submissions.select(:id)
+    ).destroy_all
+  end
+
+  def delete_challenge_phase_evaluator(cpe)
+    if cpe.destroy
+      { success: true, message: I18n.t('evaluators.remove_user_evaluator.success') }
+    else
+      { success: false, message: I18n.t('evaluators.remove_user_evaluator.failure') }
+    end
+  end
+
+  def evaluator_not_found_response
+    { success: false, message: I18n.t('evaluators.remove_user_evaluator.evaluator_not_found') }
+  end
+end

--- a/app/services/evaluator_removal_service.rb
+++ b/app/services/evaluator_removal_service.rb
@@ -25,12 +25,10 @@ class EvaluatorRemovalService
       evaluator = User.find(evaluator_id)
       cpe = ChallengePhasesEvaluator.find_by(challenge: @challenge, phase: @phase, user: evaluator)
 
-      if cpe
-        delete_evaluator_assignments(evaluator)
-        delete_challenge_phase_evaluator(cpe)
-      else
-        next evaluator_not_found_response
-      end
+      next evaluator_not_found_response unless cpe
+
+      delete_evaluator_assignments(evaluator)
+      delete_challenge_phase_evaluator(cpe)
     end
   rescue ActiveRecord::RecordNotFound
     evaluator_not_found_response

--- a/app/services/evaluator_removal_service.rb
+++ b/app/services/evaluator_removal_service.rb
@@ -22,12 +22,8 @@ class EvaluatorRemovalService
 
   def remove_user_evaluator(evaluator_id)
     ActiveRecord::Base.transaction do
-      evaluator = User.find(evaluator_id)
-      cpe = ChallengePhasesEvaluator.find_by(challenge: @challenge, phase: @phase, user: evaluator)
-
-      next evaluator_not_found_response unless cpe
-
-      delete_evaluator_assignments(evaluator)
+      cpe = find_challenge_phase_evaluator(evaluator_id)
+      delete_evaluator_assignments(cpe.user)
       delete_challenge_phase_evaluator(cpe)
     end
   rescue ActiveRecord::RecordNotFound
@@ -67,5 +63,14 @@ class EvaluatorRemovalService
 
   def evaluator_not_found_response
     { success: false, message: I18n.t('evaluators.remove_user_evaluator.evaluator_not_found') }
+  end
+
+  def find_challenge_phase_evaluator(evaluator_id)
+    evaluator = User.find(evaluator_id)
+    ChallengePhasesEvaluator.find_by(
+      challenge: @challenge,
+      phase: @phase,
+      user: evaluator
+    )
   end
 end

--- a/spec/services/evaluator_management_service_spec.rb
+++ b/spec/services/evaluator_management_service_spec.rb
@@ -116,12 +116,124 @@ RSpec.describe EvaluatorManagementService do
     context 'when removing a user evaluator' do
       let(:evaluator) { create(:user, role: 'evaluator') }
       let!(:cpe) { create(:challenge_phases_evaluator, challenge: challenge, phase: phase, user: evaluator) }
+      let!(:submission1) { create(:submission, challenge: challenge, phase: phase) }
+      let!(:submission2) { create(:submission, challenge: challenge, phase: phase) }
+      let!(:submission_other_phase) { create(:submission, challenge: challenge, phase: create(:phase, challenge: challenge)) }
 
-      it 'removes the evaluator successfully' do
-        result = service.remove_evaluator('user', evaluator.id)
-        expect(result[:success]).to be true
-        expect(result[:message]).to include('Evaluator successfully removed')
-        expect(ChallengePhasesEvaluator.find_by(id: cpe.id)).to be_nil
+      context 'with multiple assignments and evaluations' do
+        let!(:assignment1) do
+          create(:evaluator_submission_assignment,
+                submission: submission1,
+                evaluator: evaluator,
+                status: :assigned)
+        end
+
+        let!(:assignment2) do
+          create(:evaluator_submission_assignment,
+                submission: submission2,
+                evaluator: evaluator,
+                status: :recused)
+        end
+
+        let!(:assignment_other_phase) do
+          create(:evaluator_submission_assignment,
+                submission: submission_other_phase,
+                evaluator: evaluator,
+                status: :assigned)
+        end
+
+        let!(:evaluation1) do
+          create(:evaluation,
+                evaluator_submission_assignment: assignment1,
+                submission: submission1,
+                user: evaluator)
+        end
+
+        let!(:evaluation2) do
+          create(:evaluation,
+                evaluator_submission_assignment: assignment2,
+                submission: submission2,
+                user: evaluator)
+        end
+
+        it 'removes only assignments and evaluations for the specified phase' do
+          expect {
+            result = service.remove_evaluator('user', evaluator.id)
+            expect(result[:success]).to be true
+          }.to change { ChallengePhasesEvaluator.count }.by(-1)
+            .and change { EvaluatorSubmissionAssignment.count }.by(-2)
+            .and change { Evaluation.count }.by(-2)
+
+          expect(ChallengePhasesEvaluator.find_by(id: cpe.id)).to be_nil
+          expect(EvaluatorSubmissionAssignment.find_by(id: assignment1.id)).to be_nil
+          expect(EvaluatorSubmissionAssignment.find_by(id: assignment2.id)).to be_nil
+          expect(Evaluation.find_by(id: evaluation1.id)).to be_nil
+          expect(Evaluation.find_by(id: evaluation2.id)).to be_nil
+
+          expect(EvaluatorSubmissionAssignment.find_by(id: assignment_other_phase.id)).to be_present
+        end
+      end
+
+      context 'with assignments but no evaluations' do
+        let!(:assignment_no_eval) do
+          create(:evaluator_submission_assignment,
+                submission: submission1,
+                evaluator: evaluator,
+                status: :assigned)
+        end
+
+        it 'removes assignments without evaluations' do
+          expect {
+            result = service.remove_evaluator('user', evaluator.id)
+            expect(result[:success]).to be true
+          }.to change { ChallengePhasesEvaluator.count }.by(-1)
+            .and change { EvaluatorSubmissionAssignment.count }.by(-1)
+            .and change { Evaluation.count }.by(0)
+
+          expect(ChallengePhasesEvaluator.find_by(id: cpe.id)).to be_nil
+          expect(EvaluatorSubmissionAssignment.find_by(id: assignment_no_eval.id)).to be_nil
+        end
+      end
+
+      context 'when evaluator has no assignments' do
+        it 'only removes the challenge phase evaluator record' do
+          expect {
+            result = service.remove_evaluator('user', evaluator.id)
+            expect(result[:success]).to be true
+          }.to change { ChallengePhasesEvaluator.count }.by(-1)
+            .and change { EvaluatorSubmissionAssignment.count }.by(0)
+            .and change { Evaluation.count }.by(0)
+
+          expect(ChallengePhasesEvaluator.find_by(id: cpe.id)).to be_nil
+        end
+      end
+
+      context 'with successful removal' do
+        it 'returns success message' do
+          result = service.remove_evaluator('user', evaluator.id)
+          expect(result[:success]).to be true
+          expect(result[:message]).to eq(I18n.t('evaluators.remove_user_evaluator.success'))
+        end
+      end
+
+      context 'when evaluator is not found' do
+        it 'returns not found message' do
+          result = service.remove_evaluator('user', -1)
+          expect(result[:success]).to be false
+          expect(result[:message]).to eq(I18n.t('evaluators.remove_user_evaluator.evaluator_not_found'))
+        end
+      end
+
+      context 'when cpe deletion fails' do
+        before do
+          allow_any_instance_of(ChallengePhasesEvaluator).to receive(:destroy).and_return(false)
+        end
+
+        it 'returns failure message' do
+          result = service.remove_evaluator('user', evaluator.id)
+          expect(result[:success]).to be false
+          expect(result[:message]).to eq(I18n.t('evaluators.remove_user_evaluator.failure'))
+        end
       end
     end
 
@@ -133,6 +245,34 @@ RSpec.describe EvaluatorManagementService do
         expect(result[:success]).to be true
         expect(result[:message]).to include('Evaluator invitation successfully removed')
         expect(EvaluatorInvitation.find_by(id: invitation.id)).to be_nil
+      end
+
+      context 'with successful removal' do
+        it 'returns success message' do
+          result = service.remove_evaluator('invitation', invitation.id)
+          expect(result[:success]).to be true
+          expect(result[:message]).to eq(I18n.t('evaluators.remove_evaluator_invitation.success'))
+        end
+      end
+
+      context 'when invitation is not found' do
+        it 'returns not found message' do
+          result = service.remove_evaluator('invitation', -1)
+          expect(result[:success]).to be false
+          expect(result[:message]).to eq(I18n.t('evaluators.remove_evaluator_invitation.invitation_not_found'))
+        end
+      end
+
+      context 'when invitation deletion fails' do
+        before do
+          allow_any_instance_of(EvaluatorInvitation).to receive(:destroy).and_return(false)
+        end
+
+        it 'returns failure message' do
+          result = service.remove_evaluator('invitation', invitation.id)
+          expect(result[:success]).to be false
+          expect(result[:message]).to eq(I18n.t('evaluators.remove_evaluator_invitation.failure'))
+        end
       end
     end
 


### PR DESCRIPTION
Linked ticket: #112 #342 

AC: When an Evaluator is removed from a Challenge phase, we need to remove the other associations if they exist.
Currently the EvaluatorManagementService is only deleting the ChallengePhaseEvaluator, however it should also delete any EvaluatorSubmissionAssignment and Evaluation records associated with that user, if any exist.

Note: Given that EvaluatorSubmissionAssignment has `has_one :evaluation, dependent: :destroy`, when destroy_all is called on the assignments, it will trigger the dependent destroy callback and delete the associated evaluation as well.
