### PR TITLE
[391] exclude deleted submissions from evaluator evaluation status counts

### DIFF
--- a/app/helpers/evaluations_helper.rb
+++ b/app/helpers/evaluations_helper.rb
@@ -57,6 +57,7 @@ module EvaluationsHelper
     evaluator.evaluator_submission_assignments.
       joins(:submission).
       where(submissions: { challenge:, phase: }).
+      where("submissions.deleted_at" => nil).
       where(status: [:assigned, :recused]).
       count
   end
@@ -67,6 +68,7 @@ module EvaluationsHelper
     evaluator.evaluator_submission_assignments.
       joins(:submission).
       where(submissions: { challenge:, phase: }).
+      where("submissions.deleted_at" => nil).
       where(status: [:assigned, :recused]).
       left_joins(:evaluation).
       where('evaluations.completed_at IS NULL OR evaluations.id IS NULL').

--- a/spec/helpers/evaluations_helper_spec.rb
+++ b/spec/helpers/evaluations_helper_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe EvaluationsHelper, type: :helper do
       expect(helper.assigned_submissions_count(evaluator, challenge, phase)).to eq(1)
     end
 
+    it 'does not count deleted submissions' do
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+      assignment = create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+      assignment.submission.update(deleted_at: Time.now)
+
+      expect(helper.assigned_submissions_count(evaluator, challenge, phase)).to eq(2)
+    end
+
     it 'does not count unassigned or recused_unassigned submissions' do
       create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
       create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :recused)
@@ -43,6 +52,62 @@ RSpec.describe EvaluationsHelper, type: :helper do
       create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :recused_unassigned)
 
       expect(helper.assigned_submissions_count(evaluator, challenge, phase)).to eq(2)
+    end
+  end
+
+  describe '#remaining_evaluations_count' do
+    it 'returns the correct count of assigned submissions' do
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+
+      expect(helper.remaining_evaluations_count(evaluator, challenge, phase)).to eq(3)
+    end
+
+    it 'returns 0 for non-User evaluators' do
+      expect(helper.remaining_evaluations_count(nil, challenge, phase)).to eq(0)
+    end
+
+    it 'returns 0 when there are no assigned submissions' do
+      expect(helper.remaining_evaluations_count(evaluator, challenge, phase)).to eq(0)
+    end
+
+    it 'only counts submissions for the specified challenge and phase' do
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator,
+                                               submission: create(:submission, challenge: create(:challenge), phase: create(:phase)),
+                                               status: :assigned)
+
+      expect(helper.remaining_evaluations_count(evaluator, challenge, phase)).to eq(1)
+    end
+
+    it 'does not count completed submissions' do
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
+      assignment = create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+      evaluation = create(:evaluation,
+        evaluator_submission_assignment: assignment,
+        completed_at: Time.current
+      )
+
+      expect(helper.remaining_evaluations_count(evaluator, challenge, phase)).to eq(1)
+    end
+
+    it 'does not count deleted submissions' do
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+      assignment = create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :assigned)
+      assignment.submission.update(deleted_at: Time.current)
+
+      expect(helper.remaining_evaluations_count(evaluator, challenge, phase)).to eq(2)
+    end
+
+    it 'does not count unassigned or recused_unassigned submissions' do
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :recused)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :unassigned)
+      create(:evaluator_submission_assignment, evaluator: evaluator, submission: create(:submission, challenge: challenge, phase: phase), status: :recused_unassigned)
+
+      expect(helper.remaining_evaluations_count(evaluator, challenge, phase)).to eq(2)
     end
   end
 
@@ -72,18 +137,6 @@ RSpec.describe EvaluationsHelper, type: :helper do
         expect(result.formatted_score).to eq("0")
         expect(result.display_score).to eq("N/A")
       end
-    end
-  end
-
-  describe '#evaluation_submission_assignment_status_color' do
-    it 'returns correct color for not started status' do
-      allow(assignment).to receive(:evaluation_status).and_return(:not_started)
-      expect(helper.evaluation_submission_assignment_status_color(assignment)).to eq('bg-error-dark')
-    end
-
-    it 'returns correct color for completed status' do
-      allow(assignment).to receive(:evaluation_status).and_return(:completed)
-      expect(helper.evaluation_submission_assignment_status_color(assignment)).to eq('bg-success-dark')
     end
   end
 
@@ -149,22 +202,15 @@ RSpec.describe EvaluationsHelper, type: :helper do
     end
   end
 
-  describe '#assigned_submissions_count' do
-    it 'returns correct count of assigned submissions' do
-      assignment.update!(status: :assigned)
-      count = helper.assigned_submissions_count(evaluator, submission.challenge, submission.phase)
-      expect(count).to eq(1)
-    end
-
-    it 'returns zero for non-user objects' do
-      expect(helper.assigned_submissions_count(nil, submission.challenge, submission.phase)).to eq(0)
-    end
-  end
-
   describe '#evaluation_submission_assignment_status_color' do
     it 'returns correct color for not started status' do
       allow(assignment).to receive(:evaluation_status).and_return(:not_started)
       expect(helper.evaluation_submission_assignment_status_color(assignment)).to eq('bg-error-dark')
+    end
+
+    it 'returns correct color for in_progress status' do
+      allow(assignment).to receive(:evaluation_status).and_return(:in_progress)
+      expect(helper.evaluation_submission_assignment_status_color(assignment)).to eq('bg-accent-warm-dark')
     end
 
     it 'returns correct color for completed status' do


### PR DESCRIPTION
This fixes one of the issues on #391, for the Evaluators' assignment status overview. These counts were erroneously including deleted submissions in the counts which then didn't match the assignments on the next screen.
Bug demo: https://app.screencast.com/R8sgvRsovtwM1?conversation=JIVNGAoIIW4Re91PNtSjje