### PR TITLE
Fix Mailer Hostname Mismatch

### DIFF
--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,6 +1,7 @@
 Mail.defaults do
   delivery_method :smtp,
     address: ENV["SMTP_SERVER"],
-    port: (ENV["SMTP_PORT"] || 25).to_i, domain: "gsa.gov",
+    port: (ENV["SMTP_PORT"] || 25).to_i,
+    domain: ENV.fetch('HOST', 'challenge.gov'),
     openssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
 end


### PR DESCRIPTION
Fix the mailer hostname mismatch in `config/initializers/mailer.rb`

Use the host set and default to challenge.gov instead of gsa.gov.