### PR TITLE
[443] update default theme colors for evaluation_status

### DIFF
--- a/app/assets/uswds/_uswds-theme.scss
+++ b/app/assets/uswds/_uswds-theme.scss
@@ -10,7 +10,9 @@ Add a list of changed settings in the form $setting: value.
   $theme-font-path: "fonts",
   $flex-direction-settings: (
     responsive: true
-  )
+  ),
+  $theme-color-accent-warm-dark: "orange-warm-50v",
+  $theme-color-success-dark: "green-cool-60v"
 );
 
 @use "uswds" as *;


### PR DESCRIPTION
Fixes #443 
Updates the USWDS theme color for "in progress" and "completed" color bars according to the ticket.