### PR TITLE
Remove Rails Proxy and use Faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,4 @@ gem "factory_bot", "~> 6.5"
 
 gem "faker", "~> 3.4"
 
-gem "rails-reverse-proxy"
-
 gem "fog-aws"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,9 +281,6 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails-reverse-proxy (0.13.0)
-      actionpack
-      addressable
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -429,7 +426,6 @@ DEPENDENCIES
   puma (>= 6.4.3)
   rails (~> 7.2.2, >= 7.2.2.1)
   rails-controller-testing
-  rails-reverse-proxy
   rspec-rails
   rspec_junit_formatter
   rubocop (>= 1.66.0)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,22 +15,17 @@ class PagesController < ApplicationController
     response = Faraday.get(path)
     if response.status == 404
       redirect_to "/"
-      return true
     else
       body = rewrite_links(response.body)
-      render body: body, content_type: response.headers["Content-Type"], status: response.status
+      render body:, content_type: response.headers["Content-Type"], status: response.status
     end
   end
 
   def assets
     if params[:ext] == "min"
-      path = "#{HOST}#{BASE_URL}/assets/#{params[:path]}.#{params[:ext]}.js"
-      response = Faraday.get(path)
-      send_data(response.body, type: 'application/javascript')
+      handle_minified_asset
     else
-      path = "#{HOST}#{BASE_URL}/assets/#{params[:path]}.#{params[:ext]}"
-      response = Faraday.get(path)
-      render body: response.body, content_type: response.headers["Content-Type"], status: response.status
+      handle_asset
     end
   end
 
@@ -38,10 +33,22 @@ class PagesController < ApplicationController
     path = "#{HOST}#{BASE_URL}/"
     response = Faraday.get(path)
     body = rewrite_links(response.body)
-    render body: body, content_type: response.headers["Content-Type"], status: response.status
+    render body:, content_type: response.headers["Content-Type"], status: response.status
   end
 
   private
+
+  def handle_minified_asset
+    path = "#{HOST}#{BASE_URL}/assets/#{params[:path]}.#{params[:ext]}.js"
+    response = Faraday.get(path)
+    send_data(response.body, type: 'application/javascript')
+  end
+
+  def handle_asset
+    path = "#{HOST}#{BASE_URL}/assets/#{params[:path]}.#{params[:ext]}"
+    response = Faraday.get(path)
+    render body: response.body, content_type: response.headers["Content-Type"], status: response.status
+  end
 
   def rewrite_links(html)
     parsed_html = html.gsub(HOST, "/")

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,6 @@
 
 # Proxy Cloud.gov pages content at the root of the application
 class PagesController < ApplicationController
-  include ReverseProxy::Controller
   # We must remove this for proxy of JS assets to be loaded by the browser
   protect_from_forgery except: :assets
 
@@ -12,16 +11,14 @@ class PagesController < ApplicationController
   BASE_URL = Rails.configuration.static_site_interop.fetch(:base_url)
 
   def index
-    path = "#{BASE_URL}/#{params[:path]}/"
-    reverse_proxy(HOST, path:, reset_accept_encoding: true, headers: { host: DOMAIN }) do |config|
-      config.on_missing do |_code, _response|
-        redirect_to "/"
-        return true
-      end
-
-      config.on_response do |_code, response|
-        response.body = rewrite_links(response.body)
-      end
+    path = "#{HOST}#{BASE_URL}/#{params[:path]}/"
+    response = Faraday.get(path)
+    if response.status == 404
+      redirect_to "/"
+      return true
+    else
+      body = rewrite_links(response.body)
+      render body: body, content_type: response.headers["Content-Type"], status: response.status
     end
   end
 
@@ -31,20 +28,17 @@ class PagesController < ApplicationController
       response = Faraday.get(path)
       send_data(response.body, type: 'application/javascript')
     else
-      path = "#{BASE_URL}/assets/#{params[:path]}.#{params[:ext]}"
-      reverse_proxy(HOST, path:, reset_accept_encoding: true, headers: { host: DOMAIN })
+      path = "#{HOST}#{BASE_URL}/assets/#{params[:path]}.#{params[:ext]}"
+      response = Faraday.get(path)
+      render body: response.body, content_type: response.headers["Content-Type"], status: response.status
     end
   end
 
   def root
-    path = "#{BASE_URL}/"
-    reverse_proxy(HOST, path:, reset_accept_encoding: true, headers: { host: DOMAIN }) do |config|
-      config.on_response do |_code, response|
-        if response.body.present?
-          response.body = rewrite_links(response.body)
-        end
-      end
-    end
+    path = "#{HOST}#{BASE_URL}/"
+    response = Faraday.get(path)
+    body = rewrite_links(response.body)
+    render body: body, content_type: response.headers["Content-Type"], status: response.status
   end
 
   private


### PR DESCRIPTION
The rails proxy gem to load static pages content was using net/http so the static content proxy configuration couldn't be set to use the egress proxy without modification.

This moves all proxy calls to Faraday so that the global egress proxy configuration can be leveraged.

Addresses #451 