### PR TITLE
[402] Submission detail updates for challenge managers

### DIFF
--- a/app/assets/uswds/_uswds-theme.scss
+++ b/app/assets/uswds/_uswds-theme.scss
@@ -15,7 +15,7 @@ Add a list of changed settings in the form $setting: value.
   $theme-color-primary-darker: 'blue-80v',
   $theme-color-accent-warm-dark: "orange-warm-50v",
   $theme-color-success-dark: "green-cool-60v",
-  $theme-grid-container-max-width: "desktop-lg"
+  $theme-grid-container-max-width: "widescreen"
 );
 
 @use "uswds" as *;

--- a/app/assets/uswds/_uswds-theme.scss
+++ b/app/assets/uswds/_uswds-theme.scss
@@ -14,7 +14,8 @@ Add a list of changed settings in the form $setting: value.
   $theme-accordion-button-background-color: 'blue-70v',
   $theme-color-primary-darker: 'blue-80v',
   $theme-color-accent-warm-dark: "orange-warm-50v",
-  $theme-color-success-dark: "green-cool-60v"
+  $theme-color-success-dark: "green-cool-60v",
+  $theme-grid-container-max-width: "widescreen"
 );
 
 @use "uswds" as *;

--- a/app/assets/uswds/_uswds-theme.scss
+++ b/app/assets/uswds/_uswds-theme.scss
@@ -15,7 +15,7 @@ Add a list of changed settings in the form $setting: value.
   $theme-color-primary-darker: 'blue-80v',
   $theme-color-accent-warm-dark: "orange-warm-50v",
   $theme-color-success-dark: "green-cool-60v",
-  $theme-grid-container-max-width: "widescreen"
+  $theme-grid-container-max-width: "desktop-lg"
 );
 
 @use "uswds" as *;

--- a/app/javascript/controllers/submission_details_controller.js
+++ b/app/javascript/controllers/submission_details_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="submission-details"
 export default class extends Controller {
-  static targets = ["judgingStatusHidden", "eligibleCheckbox", "winnerCheckbox"];
+  static targets = ["judgingStatusHidden", "eligibleCheckbox", "winnerCheckbox", "judgingStatusForm"];
   
   eligibleCheck(e) {
     if (e.target.checked) {
@@ -10,6 +10,7 @@ export default class extends Controller {
     } else {
       this.judgingStatusHiddenTarget.value = "not_selected"
     }
+    this.submitForm()
   }
 
   selectedCheck(e) {
@@ -18,5 +19,12 @@ export default class extends Controller {
     } else {
       this.judgingStatusHiddenTarget.value = "selected"
     }
+    this.submitForm()
+  }
+
+  submitForm(e) {
+    this.judgingStatusFormTarget.submit()
   }
 }
+
+

--- a/app/views/layouts/_hotdog.html.erb
+++ b/app/views/layouts/_hotdog.html.erb
@@ -25,7 +25,7 @@
         <%= render partial: left %>
     </div>
     <div class="margin-x-4 display-flex">
-        <div class="border margin-right-neg-3 margin-left-3">
+        <div class="border-right margin-right-neg-3 margin-left-3">
         </div>    
         <div class="position-sticky top-3 bg-primary-darker border-2px radius-bottom-pill radius-top-pill width-6 height-6 margin-top-3 cursor-pointer display-flex flex-align-center" data-action="click->hotdog#hotdogCollapse" data-hotdog-target="hotdogCollapse">
             <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white margin-x-auto", alt: "Hide #{name}") %>

--- a/app/views/layouts/_hotdog.html.erb
+++ b/app/views/layouts/_hotdog.html.erb
@@ -23,13 +23,17 @@
 <div class="display-none tablet:display-flex flex-row width-full border-top-1px" data-controller="hotdog">
     <div class="width-half" data-hotdog-target="leftPane">
         <%= render partial: left %>
-    </div>  
-    <div class="bg-primary-darker margin-x-5 width-3 cursor-pointer" data-action="click->hotdog#hotdogCollapse" data-hotdog-target="hotdogCollapse">
-        <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white", alt: "Hide #{name}") %>
     </div>
-    <div class="bg-primary-darker margin-left-5 width-3 cursor-pointer display-none" data-action="click->hotdog#hotdogExpand" data-hotdog-target="hotdogExpand">
-        <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white", alt: "Show #{name}") %>
-    </div>    
+    <div class="margin-x-4 display-flex">
+        <div class="border margin-right-neg-3 margin-left-3">
+        </div>    
+        <div class="position-sticky top-3 bg-primary-darker border-2px radius-bottom-pill radius-top-pill width-6 height-6 margin-top-3 cursor-pointer display-flex flex-align-center" data-action="click->hotdog#hotdogCollapse" data-hotdog-target="hotdogCollapse">
+            <%= image_tag('images/usa-icons/arrow_forward.svg', class: "usa-icon--size-3 icon-white margin-x-auto", alt: "Hide #{name}") %>
+        </div>
+        <div class="position-sticky top-3 bg-primary-darker border-2px radius-bottom-pill radius-top-pill width-6 height-6 margin-top-3 cursor-pointer display-flex flex-align-center display-none" data-action="click->hotdog#hotdogExpand" data-hotdog-target="hotdogExpand">
+            <%= image_tag('images/usa-icons/arrow_back.svg', class: "usa-icon--size-3 icon-white margin-x-auto", alt: "Show #{name}") %>
+        </div>
+    </div>      
     <div class="width-half" data-hotdog-target="rightPane">  
         <%= render partial: right %>
     </div>  

--- a/app/views/submission_materials/_submission_materials.html.erb
+++ b/app/views/submission_materials/_submission_materials.html.erb
@@ -12,7 +12,9 @@
 <% end %>    
 
 <h2>External URL:</h2>
-<a href=<%= @submission.external_url %>><%= @submission.external_url %></a>
+<% if @submission.external_url.present? %>
+    <a href=<%= @submission.external_url %>><%= @submission.external_url %></a>
+<% end %>
 
 <h2>Status:</h2>
 <p class="text-normal"><%= @submission.status.capitalize %></p>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -20,10 +20,10 @@
       </button>
     </h2>
 
-    <div class="usa-accordion__content overflow-hidden padding-x-05" id="<%= rand %>">
+    <div class="usa-accordion__content overflow-hidden padding-left-0" id="<%= rand %>">
       <% assigned_evaluators = @submission.evaluators.where("evaluator_submission_assignments.status" => ["assigned", "recused"]) %>
       <% if assigned_evaluators.any? %>
-        <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
+        <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header width-full">
           <thead>
             <tr>
               <th scope="col">Evaluator name</th>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -59,7 +59,7 @@
                     <%= evaluator_score(assignment).formatted_score %>
                   </span>
                   <% if assignment&.evaluation&.completed_at %>
-                    <%= link_to(revision_evaluation_path(assignment.evaluation)) do %>
+                    <%= link_to(revision_evaluation_path(assignment.evaluation), class: "text-no-wrap") do %>
                         View Evaluation
                     <% end %>
                   <% end %>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -20,7 +20,7 @@
       </button>
     </h2>
 
-    <div class="usa-accordion__content overflow-hidden" id="<%= rand %>">
+    <div class="usa-accordion__content overflow-hidden padding-x-05" id="<%= rand %>">
       <% assigned_evaluators = @submission.evaluators.where("evaluator_submission_assignments.status" => ["assigned", "recused"]) %>
       <% if assigned_evaluators.any? %>
         <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
@@ -29,7 +29,7 @@
               <th scope="col">Evaluator name</th>
               <th scope="col">Evaluation Status</th>
               <th scope="col">Score</th>
-              <th scope="col"><span class="usa-sr-only">Actions</span></th>
+              <th scope="col">Action</th>
             </tr>
           </thead>
           <tbody>
@@ -57,7 +57,7 @@
                     <%= evaluator_score(assignment).formatted_score %>
                   </span>
                 </td>
-                <td data-label="">
+                <td data-label="Action">
                   <div class="display-flex flex-wrap">
                     <% if assignment&.evaluation&.completed_at %>
                       <%= link_to(revision_evaluation_path(assignment.evaluation)) do %>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -58,16 +58,14 @@
                   <span class="margin-x-1">
                     <%= evaluator_score(assignment).formatted_score %>
                   </span>
+                  <% if assignment&.evaluation&.completed_at %>
+                    <%= link_to(revision_evaluation_path(assignment.evaluation)) do %>
+                        View Evaluation
+                    <% end %>
+                  <% end %>
                 </td>
                 <td data-label="Action">
                   <div class="display-flex flex-wrap">
-                    <% if assignment&.evaluation&.completed_at %>
-                      <%= link_to(revision_evaluation_path(assignment.evaluation)) do %>
-                        <button class="usa-button font-body-3xs text-no-wrap padding-x-1 margin-bottom-1">
-                          View Evaluation
-                        </button>
-                      <% end %>
-                    <% end %>
                     <% unless @submission.winner? %>
                       <%= button_tag "Unassign", 
                           type: 'button', 

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -7,7 +7,7 @@
     </div>
   <% end %>
 
-  <div class="usa-accordion">
+  <div class="usa-accordion margin-bottom-4">
     <% rand = SecureRandom.hex(8) %>
     <h2 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
       <button

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -44,7 +44,9 @@
                         style: "vertical-align: middle; margin-right: 5px;") %>
                   <% end %>
                   <span class="text-bold text-ls-1 line-height-sans-4">
-                    <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                    <%= link_to phase_evaluator_submission_assignments_path(@submission.phase, evaluator_id: evaluator.id) do %>
+                      <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                    <% end %>
                   </span>
                 </th>
                 <td data-label="Evaluation Status" class="text-top">

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -13,7 +13,7 @@
 
   <div class="usa-accordion__content padding-x-05" id="<%= rand %>">
     <% if @submission.available_evaluators.any? %>
-        <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
+        <table aria-label="List of Available Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
           <thead>
             <tr>
               <th scope="col">Name</th>

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -17,7 +17,6 @@
           <thead>
             <tr>
               <th scope="col">Name</th>
-              <th scope="col">Email Address</th>
               <th scope="col" class="width-"># of Assigned Submissions</th>
               <th scope="col">Action</th>
             </tr>
@@ -32,9 +31,6 @@
                     <% end %>
                   </span>
                 </th>
-                <td data-label="Email Address" class="text-top width-15">
-                  <%= evaluator.email %>
-                </td>
                 <td data-label="# of Assigned Submissions" class="text-top">
                   <span class="margin-x-1">
                     <%= evaluator.assigned_submissions.count %> submissions

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -27,7 +27,9 @@
               <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
                 <th scope="row" data-label="Name" class="text-top">
                   <span class="text-bold text-ls-1 line-height-sans-4">
-                    <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                    <%= link_to phase_evaluator_submission_assignments_path(@submission.phase, evaluator_id: evaluator.id) do %>
+                      <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                    <% end %>
                   </span>
                 </th>
                 <td data-label="Email Address" class="text-top width-15">

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -1,4 +1,4 @@
-<div class="usa-accordion">
+<div class="usa-accordion margin-bottom-4">
   <% rand = SecureRandom.hex(8) %>
   <h2 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
     <button
@@ -11,9 +11,9 @@
     </button>
   </h2>
 
-  <div class="usa-accordion__content padding-x-05" id="<%= rand %>">
+  <div class="usa-accordion__content padding-left-0" id="<%= rand %>">
     <% if @submission.available_evaluators.any? %>
-        <table aria-label="List of Available Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
+        <table aria-label="List of Available Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header width-full">
           <thead>
             <tr>
               <th scope="col">Name</th>

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -11,45 +11,75 @@
     </button>
   </h2>
 
-  <div class="usa-accordion__content bg-base-lighter width-full" id="<%= rand %>">
+  <div class="usa-accordion__content padding-x-05" id="<%= rand %>">
     <% if @submission.available_evaluators.any? %>
-      <% @submission.available_evaluators.each_with_index do |evaluator, i| %>
-        <div class="display-flex flex-justify margin-y-1">
-              <div style="word-break: break-all">
-                  <span class="text-bold"><%= "#{evaluator.first_name} #{evaluator.last_name}" %></span><br/>
+        <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header">
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Email Address</th>
+              <th scope="col" class="width-"># of Assigned Submissions</th>
+              <th scope="col">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @submission.available_evaluators.each do |evaluator| %>
+              <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
+                <th scope="row" data-label="Name" class="text-top">
+                  <span class="text-bold text-ls-1 line-height-sans-4">
+                    <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                  </span>
+                </th>
+                <td data-label="Email Address" class="text-top width-15">
                   <%= evaluator.email %>
-              </div> 
-              <div class="margin-left-05">
-                  <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
-                  <% unless @submission.winner? %>
-                    <% if assignment %>
-                      <%= form_with url: phase_evaluator_submission_assignment_path(@submission.phase, assignment.id), method: "PATCH" do |f| %>
-                        <%= f.hidden_field :phase_id, value: @submission.phase.id %>
-                        <%= f.hidden_field :status, value: "assigned" %>
-                        <%= f.submit "Reassign", class: "usa-button font-body-2xs margin-top-1" %>
-                      <% end %>
-                    <% else %>
-                      <%= form_with url: phase_evaluator_submission_assignments_path(@submission.phase) do |f| %>
-                        <%= f.hidden_field :evaluator_id, value: evaluator.id %>
-                        <%= f.hidden_field :submission_id, value: @submission.id %>
-                        <%= f.submit "Assign", class: "usa-button font-body-2xs margin-top-1" %>
-                      <% end %>
+                </td>
+                <td data-label="# of Assigned Submissions" class="text-top">
+                  <span class="margin-x-1">
+                    <%= evaluator.assigned_submissions.count %> submissions
+                  </span>
+                </td>
+                <td data-label="Actions">
+                  <div class="display-flex flex-wrap">
+                    <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
+                    <% unless @submission.winner? %>
+                      <% if assignment %>
+                        <%= form_with url: phase_evaluator_submission_assignment_path(@submission.phase, assignment.id), method: "PATCH" do |f| %>
+                          <%= f.hidden_field :phase_id, value: @submission.phase.id %>
+                          <%= f.hidden_field :status, value: "assigned" %>
+                          <%= f.submit "Reassign", class: "usa-button font-body-2xs margin-top-1" %>
+                        <% end %>
+                      <% else %>
+                        <%= form_with url: phase_evaluator_submission_assignments_path(@submission.phase) do |f| %>
+                          <%= f.hidden_field :evaluator_id, value: evaluator.id %>
+                          <%= f.hidden_field :submission_id, value: @submission.id %>
+                          <%= f.submit "Assign", class: "usa-button font-body-2xs margin-top-1" %>
+                        <% end %>
+                      <% end %>  
                     <% end %>  
-                  <% end %>  
-              </div>
+                  </div>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      <% else %>
+        <div class="usa-alert usa-alert--warning">
+          <div class="usa-alert__body">
+            <p class="usa-alert__text font-body-2xs">
+              There are no evaluators available for this submission. Please visit Evaluation Panel section to manage your list of available evaluators.
+            </p>
           </div>
-          <% if i < @submission.available_evaluators.length - 1 %>
-            <hr/>
-          <% end %>  
-      <% end %>
-    <% else %>
-      <div class="usa-alert usa-alert--warning">
-        <div class="usa-alert__body">
-          <p class="usa-alert__text font-body-2xs">
-            There are no evaluators available for this submission. Please visit Evaluation Panel section to manage your list of available evaluators.
-          </p>
         </div>
+      <% end %>
+  <div class="usa-alert usa-alert--info">
+    <div class="usa-alert__body">
+        <h2 class="usa-alert__heading">
+          Need more evaluators?
+        </h2>
+        <p class="usa-alert__text font-body-2xs">
+            <%= link_to "Manage your existing evaluation panel and invite additional evaluators.", phase_evaluators_path(@submission.phase), class: "margin-y-1"  %>
+        </p>
       </div>
-    <% end %>  
+    </div> 
   </div>
 </div>

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -13,64 +13,64 @@
 
   <div class="usa-accordion__content padding-left-0" id="<%= rand %>">
     <% if @submission.available_evaluators.any? %>
-        <table aria-label="List of Available Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header width-full">
-          <thead>
-            <tr>
-              <th scope="col">Name</th>
-              <th scope="col" class="width-"># of Assigned Submissions</th>
-              <th scope="col">Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            <% @submission.available_evaluators.each do |evaluator| %>
-              <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
-                <th scope="row" data-label="Name" class="text-top">
-                  <span class="text-bold text-ls-1 line-height-sans-4">
-                    <%= link_to phase_evaluator_submission_assignments_path(@submission.phase, evaluator_id: evaluator.id) do %>
-                      <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+      <table aria-label="List of Available Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless gray-header width-full">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col" class="width-"># of Assigned Submissions</th>
+            <th scope="col">Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @submission.available_evaluators.each do |evaluator| %>
+            <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
+              <th scope="row" data-label="Name" class="text-top">
+                <span class="text-bold text-ls-1 line-height-sans-4">
+                  <%= link_to phase_evaluator_submission_assignments_path(@submission.phase, evaluator_id: evaluator.id) do %>
+                    <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                  <% end %>
+                </span>
+              </th>
+              <td data-label="# of Assigned Submissions" class="text-top">
+                <span class="margin-x-1">
+                  <%= evaluator.assigned_submissions.count %> submissions
+                </span>
+              </td>
+              <td data-label="Actions">
+                <div class="display-flex flex-wrap">
+                  <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
+                  <% unless @submission.winner? %>
+                    <% if assignment %>
+                      <%= form_with url: phase_evaluator_submission_assignment_path(@submission.phase, assignment.id), method: "PATCH" do |f| %>
+                        <%= f.hidden_field :phase_id, value: @submission.phase.id %>
+                        <%= f.hidden_field :status, value: "assigned" %>
+                        <%= f.submit "Reassign", class: "usa-button font-body-2xs margin-top-1" %>
+                      <% end %>
+                    <% else %>
+                      <%= form_with url: phase_evaluator_submission_assignments_path(@submission.phase) do |f| %>
+                        <%= f.hidden_field :evaluator_id, value: evaluator.id %>
+                        <%= f.hidden_field :submission_id, value: @submission.id %>
+                        <%= f.submit "Assign", class: "usa-button font-body-2xs margin-top-1" %>
+                      <% end %>
                     <% end %>
-                  </span>
-                </th>
-                <td data-label="# of Assigned Submissions" class="text-top">
-                  <span class="margin-x-1">
-                    <%= evaluator.assigned_submissions.count %> submissions
-                  </span>
-                </td>
-                <td data-label="Actions">
-                  <div class="display-flex flex-wrap">
-                    <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
-                    <% unless @submission.winner? %>
-                      <% if assignment %>
-                        <%= form_with url: phase_evaluator_submission_assignment_path(@submission.phase, assignment.id), method: "PATCH" do |f| %>
-                          <%= f.hidden_field :phase_id, value: @submission.phase.id %>
-                          <%= f.hidden_field :status, value: "assigned" %>
-                          <%= f.submit "Reassign", class: "usa-button font-body-2xs margin-top-1" %>
-                        <% end %>
-                      <% else %>
-                        <%= form_with url: phase_evaluator_submission_assignments_path(@submission.phase) do |f| %>
-                          <%= f.hidden_field :evaluator_id, value: evaluator.id %>
-                          <%= f.hidden_field :submission_id, value: @submission.id %>
-                          <%= f.submit "Assign", class: "usa-button font-body-2xs margin-top-1" %>
-                        <% end %>
-                      <% end %>  
-                    <% end %>  
-                  </div>
-                </td>
-              </tr>
-            <% end %>
-          </tbody>
-        </table>
-      <% else %>
-        <div class="usa-alert usa-alert--warning">
-          <div class="usa-alert__body">
-            <p class="usa-alert__text font-body-2xs">
-              There are no evaluators available for this submission. Please visit Evaluation Panel section to manage your list of available evaluators.
-            </p>
-          </div>
+                  <% end %>
+                </div>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <div class="usa-alert usa-alert--warning">
+        <div class="usa-alert__body">
+          <p class="usa-alert__text font-body-2xs">
+            There are no evaluators available for this submission. Please visit Evaluation Panel section to manage your list of available evaluators.
+          </p>
         </div>
-      <% end %>
-  <div class="usa-alert usa-alert--info">
-    <div class="usa-alert__body">
+      </div>
+    <% end %>
+    <div class="usa-alert usa-alert--info">
+      <div class="usa-alert__body">
         <h2 class="usa-alert__heading">
           Need more evaluators?
         </h2>

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -27,7 +27,7 @@
               <th scope="row" data-label="Name" class="text-top">
                 <span class="text-bold text-ls-1 line-height-sans-4">
                   <%= link_to phase_evaluator_submission_assignments_path(@submission.phase, evaluator_id: evaluator.id) do %>
-                    <%= "#{evaluator.first_name} #{evaluator.last_name}" %>
+                    <%= evaluator.full_name %>
                   <% end %>
                 </span>
               </th>

--- a/app/views/submissions/_details_form.html.erb
+++ b/app/views/submissions/_details_form.html.erb
@@ -1,48 +1,58 @@
 <div data-controller="submission-details">
     <% rand = SecureRandom.hex(8) %>
-    <%= form_with(model: @submission, url: submission_path(@submission), class: "maxw-mobile-lg") do |form| %>
-        <div class="usa-checkbox" id="eligible-for-evaluation">
+        <%= form_with(
+            model: @submission,
+            url: submission_path(@submission),
+            # method: :patch,
+            data: { 
+            submission_details_target: "judgingStatusForm"
+        }) do |f| %>  
             <input
-            class="usa-checkbox__input usa-checkbox__input--tile"
-            type="checkbox"
-            id="<%= "#{rand}-judging-status-selected" %>"
-            value="selected"
-            <%= "disabled" if @submission.evaluators_assigned? %>
-            <%= "checked" if @submission.judging_status.in?(["selected", "winner"]) %>
-            data-action="change->submission-details#eligibleCheck"
-            data-submission-details-target="eligibleCheckbox"
+            id="judging-status-hidden"
+            type="hidden"
+            name="submission[judging_status]"
+            data-submission-details-target="judgingStatusHidden"
+            value=<%= @submission.judging_status %>
             />
-            <label class="usa-checkbox__label" for="<%= "#{rand}-judging-status-selected" %>"
-            >This submission is eligible for evaluation.
-            <span class="usa-checkbox__label-description"
-                >Check the box if the submission is pre-screened and is eligible for the evaluation process.</span
-            ></label
-            >
-        </div>
-        <div class="usa-checkbox" id="selected-to-advance">
-            <input
-            class="usa-checkbox__input usa-checkbox__input--tile"
-            id="<%= "#{rand}-judging-status-winner" %>"
-            type="checkbox"
-            <%= "disabled" if @submission.evaluations_missing_or_incomplete? %>
-            <%= "checked" if @submission.judging_status == "winner" %>
-            data-action="change->submission-details#selectedCheck"
-            data-submission-details-target="winnerCheckbox"
-            />
-            <label class="usa-checkbox__label" for="<%= "#{rand}-judging-status-winner" %>"
-            >This submission is selected to advance.
-            <span class="usa-checkbox__label-description"
-                >Check the box to select this submission to advance or for award after all evaluations are completed.</span
-            ></label
-            >
-        </div>
+        <% end %>
+
+    <div class="usa-checkbox" id="eligible-for-evaluation">
         <input
-        id="judging-status-hidden"
-        type="hidden"
-        name="submission[judging_status]"
-        data-submission-details-target="judgingStatusHidden"
-        value=<%= @submission.judging_status %>
+        class="usa-checkbox__input usa-checkbox__input--tile"
+        type="checkbox"
+        id="<%= "#{rand}-judging-status-selected" %>"
+        value="selected"
+        <%= "disabled" if @submission.evaluators_assigned? %>
+        <%= "checked" if @submission.judging_status.in?(["selected", "winner"]) %>
+        data-action="change->submission-details#eligibleCheck"
+        data-submission-details-target="eligibleCheckbox"
         />
+        <label class="usa-checkbox__label" for="<%= "#{rand}-judging-status-selected" %>"
+        >This submission is eligible for evaluation.
+        <span class="usa-checkbox__label-description"
+            >Check the box if the submission is pre-screened and is eligible for the evaluation process.</span
+        ></label
+        >
+    </div>
+
+    <div class="usa-checkbox" id="selected-to-advance">
+        <input
+        class="usa-checkbox__input usa-checkbox__input--tile"
+        id="<%= "#{rand}-judging-status-winner" %>"
+        type="checkbox"
+        <%= "disabled" if @submission.evaluations_missing_or_incomplete? %>
+        <%= "checked" if @submission.judging_status == "winner" %>
+        data-action="change->submission-details#selectedCheck"
+        data-submission-details-target="winnerCheckbox"
+        />
+        <label class="usa-checkbox__label" for="<%= "#{rand}-judging-status-winner" %>"
+        >This submission is selected to advance.
+        <span class="usa-checkbox__label-description"
+            >Check the box to select this submission to advance or for award after all evaluations are completed.</span
+        ></label
+        >
+    </div>
+    <%= form_with(model: @submission, url: submission_path(@submission), class: "maxw-mobile-lg") do |form| %>
         <div class="usa-form-group">
             <%= form.label :comments, "Comments and notes:", class: "usa-label", for: "#{rand}-comments" %>
             <%= form.text_area :comments, class: "usa-textarea", default: @submission.comments, id: "#{rand}-comments" %>

--- a/app/views/submissions/_details_form.html.erb
+++ b/app/views/submissions/_details_form.html.erb
@@ -58,7 +58,8 @@
             <%= form.text_area :comments, class: "usa-textarea", default: @submission.comments, id: "#{rand}-comments" %>
         </div>
         <button type="submit" name="commit" class="usa-button font-body-2xs text-no-wrap margin-y-2">
-            Save
+            <%= image_tag('images/usa-icons/check.svg', class: "usa-icon icon-white", alt: "save notes") %>
+            Save Notes
         </button>
     <% end %>
 </div>

--- a/app/views/submissions/_details_form.html.erb
+++ b/app/views/submissions/_details_form.html.erb
@@ -58,7 +58,7 @@
             <%= form.text_area :comments, class: "usa-textarea", default: @submission.comments, id: "#{rand}-comments" %>
         </div>
         <button type="submit" name="commit" class="usa-button font-body-2xs text-no-wrap margin-y-2">
-            <%= image_tag('images/usa-icons/check.svg', class: "usa-icon icon-white", alt: "save notes") %>
+            <%= image_tag('images/usa-icons/check.svg', class: "usa-icon icon-white", alt: "save") %>
             Save Notes
         </button>
     <% end %>

--- a/app/views/submissions/_submission_evaluation.html.erb
+++ b/app/views/submissions/_submission_evaluation.html.erb
@@ -2,9 +2,6 @@
 <% if @submission.phase.evaluation_form.nil? %>
   <%= render 'shared/alert_error', alert_heading: t('alerts.no_evaluation_form.heading'), alert_text: t('alerts.no_evaluation_form.text') %>
 <% else %>
-    <%= render partial: 'assigned_evaluators' %>
     <%= render partial: 'available_evaluators' %>
-    <div class="display-flex flex-justify-end">
-      <%= link_to "Manage Evaluators", phase_evaluators_path(@submission.phase), class: "margin-y-1"  %>
-    </div>  
+    <%= render partial: 'assigned_evaluators' %>
 <% end %>

--- a/app/views/submissions/show.html.erb
+++ b/app/views/submissions/show.html.erb
@@ -1,7 +1,9 @@
 <%= render 'shared/back_link', path: submissions_phase_path(@submission.phase) %>
 
-<h1>Submission ID <%= @submission.id %></h1>
-<h2 class="font-body-sm text-normal">View submission information and assign evaluators to evaluate the submission.</h2>
+<h1><%= challenge_phase_title(@submission.challenge, @submission.phase) %></h1>
+
+<h2 class="text-primary">Submission ID <%= @submission.id %></h2>
+
 
 <%= render partial: "layouts/hotdog", locals: {
   name: 'Submission Materials',

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Submissions" do
       let(:user) { create_user(role: "challenge_manager") }
 
       it "renders a details page for an individual submission" do
-        submission = create(:submission, challenge: phase.challenge, brief_description: "This submission has legs.")
+        submission = create(:submission, challenge: phase.challenge, phase: phase, brief_description: "This submission has legs.")
 
         get submission_path(submission)
         expect(response.body).to include(submission.id.to_s)

--- a/spec/system/submission_details_spec.rb
+++ b/spec/system/submission_details_spec.rb
@@ -67,13 +67,14 @@ describe "A11y", :js do
       challenge.challenge_phases_evaluators.create(user: evaluator1, phase: phase)
       challenge.challenge_phases_evaluators.create(user: evaluator2, phase: phase)
       evaluation_form = create(:evaluation_form, phase: phase, challenge: challenge)
+      submission.update(judging_status: "selected")
       visit submission_path(submission)
-      find_by_id('eligible-for-evaluation').click
-      click_on('Save')
 
       expect(page).to have_content("Available Evaluators")
-      expect(page).to have_content(evaluator1.email)
-      expect(page).to have_content(evaluator2.email)
+      evaluator_1_path = phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator1.id)
+      evaluator_2_path = phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator2.id)
+      expect(page).to have_css("a[href=\"#{evaluator_1_path}\"]", text: evaluator1.full_name)
+      expect(page).to have_css("a[href=\"#{evaluator_2_path}\"]", text: evaluator2.full_name)
     end
 
     it "does not show solvers in the available evaluators list" do
@@ -82,13 +83,14 @@ describe "A11y", :js do
       challenge.challenge_phases_evaluators.create(user: evaluator, phase: phase)
       challenge.challenge_phases_evaluators.create(user: solver, phase: phase)
       evaluation_form = create(:evaluation_form, phase: phase, challenge: challenge)
+      submission.update(judging_status: "selected")
       visit submission_path(submission)
-      find_by_id('eligible-for-evaluation').click
-      click_on('Save')
 
       expect(page).to have_content("Available Evaluators")
-      expect(page).to have_content(evaluator.email)
-      expect(page).not_to have_content(solver.email)
+      evaluator_path = phase_evaluator_submission_assignments_path(phase, evaluator_id: evaluator.id)
+      solver_path = phase_evaluator_submission_assignments_path(phase, evaluator_id: solver.id)
+      expect(page).to have_css("a[href=\"#{evaluator_path}\"]", text: evaluator.full_name)
+      expect(page).not_to have_css("a[href=\"#{solver_path}\"]", text: solver.full_name)
     end
 
     it "assigns and unassigns an evaluator to the submission" do

--- a/spec/system/submission_details_spec.rb
+++ b/spec/system/submission_details_spec.rb
@@ -18,7 +18,7 @@ describe "A11y", :js do
     it "submission details page is accessible" do
       visit submission_path(submission)
       expect(user.role).to eq("challenge_manager")
-      expect(page).to have_css('h1', text: "Submission ID #{submission.id}")
+      expect(page).to have_css('h2', text: "Submission ID #{submission.id}")
       expect(page).to(be_axe_clean)
     end
 
@@ -28,7 +28,7 @@ describe "A11y", :js do
       eligible_input = page.find_by_id('eligible-for-evaluation').find('input.usa-checkbox__input', visible: :hidden)
       expect(eligible_input).not_to be_checked
       find_by_id('eligible-for-evaluation').click
-      click_on "Save"
+      # click_on "Save"
       expect(page).to have_css("p.usa-alert__text", text: "Submission was updated successfully.")
       eligible_input = page.find_by_id('eligible-for-evaluation').find('input.usa-checkbox__input', visible: :hidden)
       expect(eligible_input).to be_checked
@@ -46,7 +46,7 @@ describe "A11y", :js do
       selected_input = page.find_by_id('selected-to-advance').find('input.usa-checkbox__input', visible: :hidden)
       expect(selected_input).not_to be_checked
       find_by_id('selected-to-advance').click
-      click_on "Save"
+      # click_on "Save"
       expect(page).to have_css("p.usa-alert__text", text: "Submission was updated successfully.")
       selected_input = page.find_by_id('selected-to-advance').find('input.usa-checkbox__input', visible: :hidden)
       expect(selected_input).to be_checked


### PR DESCRIPTION
Updates the submission details page for challenge managers to the latest designs. 

major changes:

- changes the judging status checkboxes to each trigger their own form submit. I first used json to make these checkboxes write to the db without a page refresh but since we are showing / hiding sections of the page based on this action I think a full page refresh is justified.
-  changes the hotdog layout to a new design. The arrow now sticks to the page when scrolling. 
- adds columns to the available evaluators accordion. 
- changes the max width of the app-wide grid container to "widescreen" which allows for wider hotdog widths and no horizontal scroll on an average-sized laptop screen.

<img width="1341" alt="Screen Shot 2025-03-03 at 4 04 12 PM" src="https://github.com/user-attachments/assets/2b084ef3-fe11-4e50-b856-5f2b33840146" />

<img width="1352" alt="Screen Shot 2025-03-03 at 4 03 47 PM" src="https://github.com/user-attachments/assets/1561ece3-c1c0-4f9f-bd89-d69284504469" />
