### PR TITLE
[455] Update Sender Email Address for Transactional Emails

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,6 +3,6 @@
 # The main app mailer for sending emails.
 # The app does not process inbound messages.
 class ApplicationMailer < ActionMailer::Base
-  default from: "support@challenge.gov"
+  default from: "team@challenge.gov"
   layout "mailer"
 end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.evaluation_invitation.subject", challenge_title: challenge.title))
       expect(mail.to).to eq([invitation.email])
-      expect(mail.from).to eq(["support@challenge.gov"])
+      expect(mail.from).to eq(["team@challenge.gov"])
     end
 
     it "renders the body" do
@@ -53,7 +53,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.evaluation_invitation.subject", challenge_title: challenge.title))
       expect(mail.to).to eq([user.email])
-      expect(mail.from).to eq(["support@challenge.gov"])
+      expect(mail.from).to eq(["team@challenge.gov"])
     end
 
     it "renders the body" do
@@ -74,7 +74,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.evaluation_assignment.subject", submission_id: submission.id))
       expect(mail.to).to eq([evaluator.email])
-      expect(mail.from).to eq(["support@challenge.gov"])
+      expect(mail.from).to eq(["team@challenge.gov"])
     end
 
     it "renders the body" do
@@ -118,7 +118,7 @@ RSpec.describe NotificationMailer, type: :mailer do
     it "renders the headers" do
       expect(mail.subject).to eq(I18n.t("mailers.recusal.subject", submission_id: submission.id))
       expect(mail.to).to eq([challenge_manager.email])
-      expect(mail.from).to eq(["support@challenge.gov"])
+      expect(mail.from).to eq(["team@challenge.gov"])
     end
 
     it "renders the body" do


### PR DESCRIPTION
Linked ticket: #455 

Update sender email address for transactional emails to `team@challenge.gov`.

