### PR TITLE
[456] Evaluator Approval and Availability Status bug

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,6 +53,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
+  Max: 150
   CountAsOne:
     - array
     - hash
@@ -60,6 +61,13 @@ Metrics/ClassLength:
 
 Metrics/MethodLength:
   Max: 20
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
+
+Metrics/ModuleLength:
+  Max: 150
   CountAsOne:
     - array
     - hash

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,11 +32,11 @@ class ApplicationController < ActionController::Base
     redirect_to_landing_page(alert: I18n.t("access_denied"))
   end
 
-  # All evaluators must be active for authorization
+  # All evaluators must be active to pass this authorization
   def authorize_active_evaluators
-    if current_user.role == 'evaluator' && current_user.status != 'active'
-      redirect_to "/", alert: I18n.t("evaluator_pending_approval")
-    end
+    return unless current_user.role == 'evaluator' && current_user.status != 'active'
+
+    redirect_to "/", alert: I18n.t("evaluator_pending_approval")
   end
 
   def check_gov_access

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,13 @@ class ApplicationController < ActionController::Base
     redirect_to_landing_page(alert: I18n.t("access_denied"))
   end
 
+  # All evaluators must be active for authorization
+  def authorize_active_evaluators
+    if current_user.role == 'evaluator' && current_user.status != 'active'
+      redirect_to "/", alert: I18n.t("evaluator_pending_approval")
+    end
+  end
+
   def check_gov_access
     return unless current_user.non_gov_restricted?
 

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -129,6 +129,7 @@ class EvaluationsController < ApplicationController
 
   def authorize_active_evaluators
     return if current_user.status == 'active'
+
     redirect_to "/", alert: I18n.t("evaluator_pending_approval")
   end
 

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -3,6 +3,7 @@
 # Controller for evaluations CRUD actions.
 class EvaluationsController < ApplicationController
   before_action -> { authorize_user('evaluator') }
+  before_action :authorize_active_evaluators
   before_action :set_evaluation_and_submission_assignment, only: %i[create update]
 
   def index
@@ -124,6 +125,11 @@ class EvaluationsController < ApplicationController
   # Auth Helpers
   def can_access_evaluation?
     @evaluator_submission_assignment && @evaluator_submission_assignment.user_id == current_user.id
+  end
+
+  def authorize_active_evaluators
+    return if current_user.status == 'active'
+    redirect_to "/", alert: I18n.t("evaluator_pending_approval")
   end
 
   # Redirect Helpers

--- a/app/controllers/evaluations_controller.rb
+++ b/app/controllers/evaluations_controller.rb
@@ -3,7 +3,7 @@
 # Controller for evaluations CRUD actions.
 class EvaluationsController < ApplicationController
   before_action -> { authorize_user('evaluator') }
-  before_action :authorize_active_evaluators
+  before_action -> { authorize_active_evaluators }
   before_action :set_evaluation_and_submission_assignment, only: %i[create update]
 
   def index
@@ -125,12 +125,6 @@ class EvaluationsController < ApplicationController
   # Auth Helpers
   def can_access_evaluation?
     @evaluator_submission_assignment && @evaluator_submission_assignment.user_id == current_user.id
-  end
-
-  def authorize_active_evaluators
-    return if current_user.status == 'active'
-
-    redirect_to "/", alert: I18n.t("evaluator_pending_approval")
   end
 
   # Redirect Helpers

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -32,7 +32,11 @@ class PagesController < ApplicationController
   def root
     path = "#{HOST}#{BASE_URL}/"
     response = Faraday.get(path)
-    body = rewrite_links(response.body)
+    body = render_flash_message(
+      rewrite_links(
+        response.body
+      )
+    )
     render body:, content_type: response.headers["Content-Type"], status: response.status
   end
 
@@ -61,5 +65,13 @@ class PagesController < ApplicationController
     # rubocop:disable Rails/OutputSafety
     parsed_html.html_safe
     # rubocop:enable Rails/OutputSafety
+  end
+
+  def render_flash_message(html)
+    main_index = html.index('<main id="main-content">')
+    return html if flash.empty? || main_index.nil?
+
+    flash_message = render_to_string(partial: "shared/flash")
+    return html.insert(main_index, flash_message)
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -72,6 +72,6 @@ class PagesController < ApplicationController
     return html if flash.empty? || main_index.nil?
 
     flash_message = render_to_string(partial: "shared/flash")
-    return html.insert(main_index, flash_message)
+    html.insert(main_index, flash_message)
   end
 end

--- a/app/controllers/submission_materials_controller.rb
+++ b/app/controllers/submission_materials_controller.rb
@@ -4,6 +4,7 @@
 class SubmissionMaterialsController < ApplicationController
   before_action -> { authorize_user('challenge_manager', 'evaluator') }
   before_action -> { check_gov_access }
+  before_action -> { authorize_active_evaluators }
 
   def show
     @submission = Submission.by_user(current_user).find(params[:id])

--- a/app/helpers/evaluation_scores_helper.rb
+++ b/app/helpers/evaluation_scores_helper.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 # View helpers for evaluation score form inputs
-
-# rubocop:disable Metrics/ModuleLength
 module EvaluationScoresHelper
   def evaluation_score_id(_form, attribute, identifier)
     prefix = "evaluation_evaluation_scores_attributes"
@@ -132,4 +130,3 @@ module EvaluationScoresHelper
     weighted_scoring ? "#{formatted_score}%" : formatted_score
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/app/helpers/evaluators_helper.rb
+++ b/app/helpers/evaluators_helper.rb
@@ -15,6 +15,11 @@ module EvaluatorsHelper
     end
   end
 
+  def evaluator_available_for_assignment?(evaluator)
+    return false unless evaluator.is_a?(User)
+    evaluator.role == 'evaluator' && evaluator.status == 'active'
+  end
+
   # Combined status of all evaluations for the phase assigned to the user
   # NOTE: :recused is considered 'assigned' for evaluation_status here
   def evaluator_evaluation_status(evaluator, phase)

--- a/app/helpers/evaluators_helper.rb
+++ b/app/helpers/evaluators_helper.rb
@@ -17,6 +17,7 @@ module EvaluatorsHelper
 
   def evaluator_available_for_assignment?(evaluator)
     return false unless evaluator.is_a?(User)
+
     evaluator.role == 'evaluator' && evaluator.status == 'active'
   end
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -103,7 +103,7 @@ class Submission < ApplicationRecord
   # Phase evaluators not currently assigned or recused on the submission
   def available_evaluators
     unavailable_evaluators = evaluators.where.not("evaluator_submission_assignments.status" => "unassigned")
-    phase.evaluators.where.not(id: unavailable_evaluators).where(role: "evaluator")
+    phase.evaluators.where.not(id: unavailable_evaluators).where(role: "evaluator", status: "active")
   end
 
   def eligible_for_evaluation?

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -106,9 +106,13 @@
             <% @existing_evaluators.each do |evaluator| %>
               <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
                 <th scope="row" data-label="Name" class="text-top">
+                <% if evaluator_available_for_assignment?(evaluator) %>
                     <%= link_to phase_evaluator_submission_assignments_path(@phase, evaluator_id: evaluator.id) do %>
                       <%= evaluator.full_name %>
-                    <% end %>  
+                    <% end %>
+                <% else %>
+                  <span class="text-bold text-ls-1 line-height-sans-4"><%= evaluator.full_name %></span>
+                <% end %>
                 </th>
                 <td data-label="Email Address" class="text-top"><%= evaluator.email %></td>
                 <td data-label="User Role" class="text-top"><%= evaluator.role.titleize %></td>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -107,11 +107,11 @@
               <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
                 <th scope="row" data-label="Name" class="text-top">
                 <% if evaluator_available_for_assignment?(evaluator) %>
-                    <%= link_to phase_evaluator_submission_assignments_path(@phase, evaluator_id: evaluator.id) do %>
-                      <%= evaluator.full_name %>
-                    <% end %>
+                  <%= link_to phase_evaluator_submission_assignments_path(@phase, evaluator_id: evaluator.id) do %>
+                    <%= evaluator.full_name %>
+                  <% end %>
                 <% else %>
-                  <span class="text-bold text-ls-1 line-height-sans-4"><%= evaluator.full_name %></span>
+                  <%= evaluator.full_name %>
                 <% end %>
                 </th>
                 <td data-label="Email Address" class="text-top"><%= evaluator.email %></td>
@@ -176,7 +176,7 @@
           </tbody>
         </table>
       </div>
-      <div class="usa-alert usa-alert--info width-tablet margin-bottom-5">
+      <div class="usa-alert usa-alert--info maxw-tablet margin-bottom-5">
         <div class="usa-alert__body">
           <h2 class="usa-alert__heading">
             Assign evaluators to submissions

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -116,12 +116,18 @@
                 <td data-label="# of Assigned Submissions" class="text-top">
                   <% submissions_count = assigned_submissions_count(evaluator, @challenge, @phase) %>
                   <% if submissions_count > 0 %>
-                    <%= link_to phase_evaluator_submission_assignments_path(@phase, evaluator_id: evaluator.id), class: '', style: 'white-space: nowrap;' do %>
-                      <%= submissions_count %> submissions
+                    <% if evaluator_available_for_assignment?(evaluator) %>
+                      <%= link_to phase_evaluator_submission_assignments_path(@phase, evaluator_id: evaluator.id), class: '', style: 'white-space: nowrap;' do %>
+                        <%= submissions_count %> submissions
+                      <% end %>
+                    <% else %>
+                      <span style="white-space: nowrap;">
+                        <%= submissions_count %> submissions
+                      </span>
                     <% end %>
                   <% else %>
                     0 submissions
-                  <% end %>    
+                  <% end %>
                 </td>
                 <td data-label="">
                   <div class="display-flex flex-no-wrap grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@
 
 en:
   access_denied: "You do not have access to this section of Challenge.gov."
+  evaluator_pending_approval: "You do not have access to Challenge.gov, your account is pending approval."
   already_logged_in_notice: "You are already logged in."
   evaluation_form_destroyed: "Evaluation form was successfully destroyed."
   evaluation_form_saved: "Evaluation form was saved successfully."

--- a/spec/helpers/evaluators_helper_spec.rb
+++ b/spec/helpers/evaluators_helper_spec.rb
@@ -53,6 +53,29 @@ RSpec.describe EvaluatorsHelper, type: :helper do
     end
   end
 
+  describe '#evaluator_available_for_assignment?' do
+    let(:evaluator) { create(:user, role: 'evaluator') }
+
+    it 'returns true for active evaluator' do
+      evaluator.update(status: 'active')
+      expect(helper.evaluator_available_for_assignment?(evaluator)).to be true
+    end
+
+    it 'returns false for pending evaluator' do
+      evaluator.update(status: 'pending')
+      expect(helper.evaluator_available_for_assignment?(evaluator)).to be false
+    end
+
+    it 'returns false for non-evaluator user' do
+      user = create(:user, role: 'challenge_manager')
+      expect(helper.evaluator_available_for_assignment?(user)).to be false
+    end
+
+    it 'returns false for nil user' do
+      expect(helper.evaluator_available_for_assignment?(nil)).to be false
+    end
+  end
+
   describe '#user_status' do
     it 'returns "Invite Sent" for non-User objects' do
       expect(helper.user_status(nil)).to eq("Invite Sent")

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   end
 
   describe "#evaluation_assignment" do
-    let(:evaluator) { create(:user, role: "evaluator") }
+    let(:evaluator) { create(:user, role: "evaluator", status: "active") }
     let(:submission) { create(:submission, challenge: challenge, phase: phase) }
     let(:assignment) { create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :assigned) }
     let(:mail) { described_class.evaluation_assignment(assignment) }
@@ -105,7 +105,7 @@ RSpec.describe NotificationMailer, type: :mailer do
   end
 
   describe "#recusal" do
-    let(:evaluator) { create(:user, role: "evaluator") }
+    let(:evaluator) { create(:user, role: "evaluator", status: "active") }
     let(:submission) { create(:submission, challenge: challenge, phase: phase) }
     let(:assignment) { create(:evaluator_submission_assignment, evaluator: evaluator, submission: submission, status: :recused) }
     let(:mail) { described_class.recusal(assignment) }

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Submission, type: :model do
     let(:challenge) { create(:challenge) }
     let(:phase) { create(:phase, challenge:) }
     let(:evaluator) do
-      evaluator = create(:user, role: "evaluator")
+      evaluator = create(:user, role: "evaluator", status: "active")
       evaluator.challenge_phases_evaluators.create(challenge:, phase:)
       evaluator
     end

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe "Evaluations" do
 
     context "when logged in as an evaluator" do
       before do
-        create_and_log_in_user(role: "evaluator")
+        create_and_log_in_user(role: "evaluator", status: "active")
         get "/evaluations"
       end
 
@@ -70,7 +70,7 @@ RSpec.describe "Evaluations" do
     end
 
     context "when logged in as an evaluator" do
-      let(:evaluator) { create_and_log_in_user(role: 'evaluator') }
+      let(:evaluator) { create_and_log_in_user(role: 'evaluator', status: 'active') }
 
       let(:challenge_with_submissions) do
         create(:challenge, title: "Challenge with Submissions", is_multi_phase: false)
@@ -164,10 +164,82 @@ RSpec.describe "Evaluations" do
         end
       end
     end
+
+    context "when evaluator status authorization" do
+      let(:challenge) { create(:challenge) }
+      let(:phase) { create(:phase, challenge: challenge) }
+      let(:submission) { create(:submission, phase: phase, challenge: challenge) }
+      let(:evaluation_form) { create(:evaluation_form, phase: phase, challenge: challenge) }
+
+      context "when evaluator is pending" do
+        let(:pending_evaluator) { create(:user, role: 'evaluator', status: 'pending') }
+
+        before do
+          log_in_user(pending_evaluator)
+          ChallengePhasesEvaluator.create!(challenge: challenge, phase: phase, user: pending_evaluator)
+        end
+
+        it "cannot access evaluations index" do
+          get evaluations_path
+          expect(response).to redirect_to("/")
+          expect(flash[:alert]).to eq(I18n.t("evaluator_pending_approval"))
+        end
+
+        it "cannot access submissions page" do
+          get submissions_evaluation_path(phase)
+          expect(response).to redirect_to("/")
+          expect(flash[:alert]).to eq(I18n.t("evaluator_pending_approval"))
+        end
+
+        it "cannot access new evaluation page" do
+          get new_submission_evaluation_path(submission)
+          expect(response).to redirect_to("/")
+          expect(flash[:alert]).to eq(I18n.t("evaluator_pending_approval"))
+        end
+
+        it "cannot access edit evaluation page" do
+          evaluation = create(:evaluation, user: pending_evaluator, evaluation_form: evaluation_form)
+          get edit_evaluation_path(evaluation)
+          expect(response).to redirect_to("/")
+          expect(flash[:alert]).to eq(I18n.t("evaluator_pending_approval"))
+        end
+      end
+
+      context "when evaluator is active" do
+        let(:active_evaluator) { create(:user, role: 'evaluator', status: 'active') }
+        let!(:evaluation_form) { create(:evaluation_form, phase: phase, challenge: challenge) }
+        let!(:assignment) do
+          create(:evaluator_submission_assignment,
+                 submission: submission,
+                 evaluator: active_evaluator,
+                 status: :assigned)
+        end
+
+        before do
+          log_in_user(active_evaluator)
+          ChallengePhasesEvaluator.create!(challenge: challenge, phase: phase, user: active_evaluator)
+        end
+
+        it "can access evaluations index" do
+          get evaluations_path
+          expect(response).to have_http_status(:success)
+        end
+
+        it "can access submissions page" do
+          get submissions_evaluation_path(phase)
+          expect(response).to have_http_status(:success)
+        end
+
+        it "can access new evaluation page" do
+          get new_submission_evaluation_path(submission)
+          expect(response).to have_http_status(:success)
+        end
+      end
+    end
   end
 
   describe "GET /evaluations/:id/submissions" do
-    let(:evaluator) { create(:user, role: 'evaluator') }
+    let(:evaluator) { create(:user, role: 'evaluator', status: 'active') }
     let(:challenge) { create(:challenge) }
     let(:phase) { create(:phase, challenge: challenge) }
     let!(:evaluation_form) { create(:evaluation_form, phase: phase, challenge: challenge) }
@@ -243,7 +315,7 @@ RSpec.describe "Evaluations" do
     end
 
     context "when logged in as an evaluator not associated with the challenge phase" do
-      let(:unassociated_evaluator) { create(:user, role: 'evaluator') }
+      let(:unassociated_evaluator) { create(:user, role: 'evaluator', status: 'active') }
       let(:other_challenge) { create(:challenge) }
       let(:other_phase) { create(:phase, challenge: other_challenge) }
 
@@ -274,7 +346,7 @@ RSpec.describe "Evaluations" do
   end
 
   describe "GET /evaluations/:id/revision" do
-    let(:evaluator) { create(:user, role: 'evaluator') }
+    let(:evaluator) { create(:user, role: 'evaluator', status: 'active') }
     let(:challenge_manager) { create(:user, role: 'challenge_manager') }
     let(:challenge) { create(:challenge) }
     let(:phase) { create(:phase, challenge: challenge) }
@@ -352,7 +424,7 @@ RSpec.describe "Evaluations" do
   # new_submission_evaluation_path
   describe "GET /evaluator_submission_assignments/:evaluator_submission_assignment_id/evaluations/new" do
     context "when logged in as an evaluator" do
-      let(:current_user) { create_user(role: "evaluator") }
+      let(:current_user) { create_user(role: "evaluator", status: "active") }
       let(:challenge) { create(:challenge) }
       let(:phase) { create(:phase, challenge:) }
       let(:submission) { create(:submission, challenge:, phase:) }
@@ -412,7 +484,7 @@ RSpec.describe "Evaluations" do
   # evaluations_path
   describe "POST /evaluations" do
     context "when logged in as an evaluator" do
-      let(:current_user) { create_user(role: "evaluator") }
+      let(:current_user) { create_user(role: "evaluator", status: "active") }
 
       before { log_in_user(current_user) }
 
@@ -473,7 +545,7 @@ RSpec.describe "Evaluations" do
 
   describe "POST /evaluations" do
     context "when logged in as an evaluator" do
-      let(:current_user) { create_user(role: "evaluator") }
+      let(:current_user) { create_user(role: "evaluator", status: "active") }
 
       before { log_in_user(current_user) }
 
@@ -551,7 +623,7 @@ RSpec.describe "Evaluations" do
   # edit_evaluation_path
   describe "GET /evaluations/:id/edit" do
     context "when logged in as an evaluator" do
-      let(:current_user) { create_user(role: "evaluator") }
+      let(:current_user) { create_user(role: "evaluator", status: "active") }
       let(:challenge) { create(:challenge) }
       let(:phase) { create(:phase, challenge:) }
       let(:submission) { create(:submission, challenge:, phase:) }
@@ -634,7 +706,7 @@ RSpec.describe "Evaluations" do
 
   describe "PATCH /evaluations/:id" do
     context "when logged in as an evaluator" do
-      let(:current_user) { create_user(role: "evaluator") }
+      let(:current_user) { create_user(role: "evaluator", status: "active") }
 
       before { log_in_user(current_user) }
 
@@ -785,7 +857,7 @@ RSpec.describe "Evaluations" do
   # recuse on a new evaluation that has not been started
   describe "PATCH /submissions/:submission_id/evaluations/recuse" do
     context "when logged in as an evaluator" do
-      let(:current_user) { create_user(role: "evaluator") }
+      let(:current_user) { create_user(role: "evaluator", status: "active") }
 
       before { log_in_user(current_user) }
 

--- a/spec/requests/phases_spec.rb
+++ b/spec/requests/phases_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Phases" do
 
     context "when logged in as an evaluator" do
       before do
-        create_and_log_in_user(role: "evaluator")
+        create_and_log_in_user(role: "evaluator", status: "active")
       end
 
       it "redirects to the evaluator landing page" do

--- a/spec/requests/submission_materials_spec.rb
+++ b/spec/requests/submission_materials_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe "SubmissionMaterialsController" do
 
   context "when logged in as an evaluator" do
     let(:user) do
-      create_and_log_in_user(role: "evaluator")
+      create_and_log_in_user(role: "evaluator", status: "active")
     end
 
     context "with a gov email" do

--- a/spec/requests/submissions_spec.rb
+++ b/spec/requests/submissions_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Submissions" do
     end
 
     context "when logged in as an evaluator" do
-      let(:user) { create_user(role: "evaluator") }
+      let(:user) { create_user(role: "evaluator", status: "active") }
 
       it "redirects to the landing page" do
         get submissions_phase_path(phase)

--- a/spec/system/logins_spec.rb
+++ b/spec/system/logins_spec.rb
@@ -28,7 +28,7 @@ describe "A11y", :js do
   end
 
   describe "Logged-in as an Evaluator" do
-    let(:user) { create_user(role: "evaluator") }
+    let(:user) { create_user(role: "evaluator", status: "active") }
 
     it "evaluations index page is accessible" do
       visit evaluations_path

--- a/spec/system/submission_details_spec.rb
+++ b/spec/system/submission_details_spec.rb
@@ -37,7 +37,7 @@ describe "A11y", :js do
 
     it "allows marking judging status selected to advance" do
       # evaluations must exist and all be completed before selecting the submission to advance
-      evaluator = create_user(role: "evaluator")
+      evaluator = create_user(role: "evaluator", status: "active")
       submission.update(judging_status: :selected)
       assignment = create(:evaluator_submission_assignment, status: :assigned, evaluator:, submission:)
       create(:evaluation, evaluator_submission_assignment: assignment, completed_at: Time.current)
@@ -62,8 +62,8 @@ describe "A11y", :js do
     end
 
     it "displays a list of available evaluators" do
-      evaluator1 = create_user(role: "evaluator")
-      evaluator2 = create_user(role: "evaluator")
+      evaluator1 = create_user(role: "evaluator", status: "active")
+      evaluator2 = create_user(role: "evaluator", status: "active")
       challenge.challenge_phases_evaluators.create(user: evaluator1, phase: phase)
       challenge.challenge_phases_evaluators.create(user: evaluator2, phase: phase)
       evaluation_form = create(:evaluation_form, phase: phase, challenge: challenge)
@@ -78,7 +78,7 @@ describe "A11y", :js do
     end
 
     it "does not show solvers in the available evaluators list" do
-      evaluator = create_user(role: "evaluator")
+      evaluator = create_user(role: "evaluator", status: "active")
       solver = create_user(role: "solver")
       challenge.challenge_phases_evaluators.create(user: evaluator, phase: phase)
       challenge.challenge_phases_evaluators.create(user: solver, phase: phase)
@@ -94,7 +94,7 @@ describe "A11y", :js do
     end
 
     it "assigns and unassigns an evaluator to the submission" do
-      evaluator = create_user(role: "evaluator")
+      evaluator = create_user(role: "evaluator", status: "active")
       challenge.challenge_phases_evaluators.create(user: evaluator, phase: phase)
       evaluation_form = create(:evaluation_form, phase: phase, challenge: challenge)
       visit submission_path(submission)
@@ -117,7 +117,7 @@ describe "A11y", :js do
     end
 
     it "unassigns a recused evaluator from the submission" do
-      evaluator = create_user(role: "evaluator")
+      evaluator = create_user(role: "evaluator", status: "active")
       challenge.challenge_phases_evaluators.create(user: evaluator, phase: phase)
       evaluation_form = create(:evaluation_form, phase: phase, challenge: challenge)
       visit submission_path(submission)


### PR DESCRIPTION
Linked ticket: #456 

Fix evaluator approval and availability status bug.

ACs:
- [x] User status changes to 'Available' when the evaluator role is approved by an admin
- [x] Only evaluators with Available (active) user status are available to be assigned to submissions
- [x] Non-active evaluators are not displayed in the available evaluators table on the submission detail page
- [x] A non-active evaluator should not be able to login to Challenge.gov until their account is approved
- [x] Adjust specs to use active evaluators

<img width="1085" alt="Screenshot 2025-03-11 at 3 42 05 PM" src="https://github.com/user-attachments/assets/248b04d9-4163-41c9-b449-0ef45cf24fa2" />

