### PR TITLE
[402/fix] Submission Detail Page Updates - Challenge Manager

### DIFF
--- a/app/views/shared/_alert_error.html.erb
+++ b/app/views/shared/_alert_error.html.erb
@@ -2,7 +2,7 @@
   <div class="maxw-tablet">
     <div class="usa-alert usa-alert--error padding-top-105" role="alert">
       <div class="usa-alert__body">
-        <h2 class="usa-alert__heading"><%= alert_heading %></h2>
+        <h3 class="usa-alert__heading"><%= alert_heading %></h3>
         <p class="usa-alert__text">
           <%= alert_text %>
         </p>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -1,12 +1,4 @@
 <div data-controller="unassign-evaluator-submission-modal">
-  <% if @submission.evaluator_submission_assignments.recused.exists? %>
-    <div class="margin-bottom-2">
-      <%= render 'shared/alert_error', 
-          alert_heading: t('alerts.recused_evaluator.heading'), 
-          alert_text: t('alerts.recused_evaluator_submission.text') %>
-    </div>
-  <% end %>
-
   <div class="usa-accordion margin-bottom-4">
     <% rand = SecureRandom.hex(8) %>
     <h4 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
@@ -21,6 +13,14 @@
     </h4>
 
     <div class="usa-accordion__content overflow-hidden padding-left-0" id="<%= rand %>">
+      <% if @submission.evaluator_submission_assignments.recused.exists? %>
+        <div class="margin-bottom-2">
+          <%= render 'shared/alert_error', 
+              alert_heading: t('alerts.recused_evaluator.heading'), 
+              alert_text: t('alerts.recused_evaluator_submission.text') %>
+        </div>
+      <% end %>
+
       <% assigned_evaluators = @submission.evaluators.where("evaluator_submission_assignments.status" => ["assigned", "recused"]) %>
       <% if assigned_evaluators.any? %>
         <table aria-label="List of Assigned Evaluators" class="usa-table usa-table--stacked-header usa-table--borderless challenge-table width-full">
@@ -37,12 +37,6 @@
               <% assignment = evaluator.evaluator_submission_assignments.where(submission_id: @submission.id).first %>
               <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
                 <th scope="row" data-label="Evaluator name" class="text-top">
-                  <% if assignment.status == "recused" %>
-                    <%= image_tag('images/usa-icons/error.svg', 
-                        class: "usa-icon--size-3", 
-                        alt: "Recused", 
-                        style: "vertical-align: middle; margin-right: 5px;") %>
-                  <% end %>
                   <span class="text-bold text-ls-1 line-height-sans-4">
                     <%= link_to phase_evaluator_submission_assignments_path(@submission.phase, evaluator_id: evaluator.id) do %>
                       <%= "#{evaluator.first_name} #{evaluator.last_name}" %>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -9,7 +9,7 @@
 
   <div class="usa-accordion margin-bottom-4">
     <% rand = SecureRandom.hex(8) %>
-    <h2 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
+    <h4 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
       <button
         type="button"
         class="usa-accordion__button display-flex flex-justify"
@@ -18,7 +18,7 @@
       >
         <div>Assigned Evaluators</div>
       </button>
-    </h2>
+    </h4>
 
     <div class="usa-accordion__content overflow-hidden padding-left-0" id="<%= rand %>">
       <% assigned_evaluators = @submission.evaluators.where("evaluator_submission_assignments.status" => ["assigned", "recused"]) %>

--- a/app/views/submissions/_assigned_evaluators.html.erb
+++ b/app/views/submissions/_assigned_evaluators.html.erb
@@ -80,8 +80,11 @@
       <% else %>
         <div class="usa-alert usa-alert--warning maxw-tablet">
           <div class="usa-alert__body">
+            <h3 class="usa-alert__heading">
+              No Assigned Evaluators
+            </h3>
             <p class="usa-alert__text font-body-2xs">
-              You currently do not have any evaluators assigned to this submission. Please use the section below to review and assign available evaluators.
+              This submission does not have any assigned evaluators. Please use the Available Evaluators section above to assign evaluators.
             </p>
           </div>
         </div>

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -60,24 +60,33 @@
           <% end %>
         </tbody>
       </table>
+    <% end %>
+
+    <% if !@submission.phase.challenge_phases_evaluators.any? %>
+      <div class="usa-alert usa-alert--info maxw-tablet">
+        <div class="usa-alert__body">
+          <h3 class="usa-alert__heading">
+            Need more evaluators?
+          </h3>
+          <p class="usa-alert__text font-body-2xs">
+            <%= link_to "Manage your existing evaluation panel and invite additional evaluators.", phase_evaluators_path(@submission.phase), class: "margin-y-1"  %>
+          </p>
+        </div>
+      </div> 
     <% else %>
       <div class="usa-alert usa-alert--warning maxw-tablet">
         <div class="usa-alert__body">
+          <h3 class="usa-alert__heading">
+            No Evaluation Panel
+          </h3>
           <p class="usa-alert__text font-body-2xs">
-            There are no evaluators available for this submission. Please visit Evaluation Panel section to manage your list of available evaluators.
+            You have not yet created an evaluation panel for this challenge. 
+            <%= link_to "Create an evaluation panel and invite evaluators to start an evaluation process.", phase_evaluators_path(@submission.phase) %> 
           </p>
         </div>
       </div>
     <% end %>
-    <div class="usa-alert usa-alert--info maxw-tablet">
-      <div class="usa-alert__body">
-        <h3 class="usa-alert__heading">
-          Need more evaluators?
-        </h3>
-        <p class="usa-alert__text font-body-2xs">
-            <%= link_to "Manage your existing evaluation panel and invite additional evaluators.", phase_evaluators_path(@submission.phase), class: "margin-y-1"  %>
-        </p>
-      </div>
-    </div> 
   </div>
 </div>
+
+

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -62,7 +62,7 @@
       </table>
     <% end %>
 
-    <% if !@submission.phase.challenge_phases_evaluators.any? %>
+    <% if @submission.phase.challenge_phases_evaluators.any? %>
       <div class="usa-alert usa-alert--info maxw-tablet">
         <div class="usa-alert__body">
           <h3 class="usa-alert__heading">

--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -1,6 +1,6 @@
 <div class="usa-accordion margin-bottom-4">
   <% rand = SecureRandom.hex(8) %>
-  <h2 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
+  <h4 class="usa-accordion__heading" id="<%= "#{rand}-accordion-heading" %>">
     <button
       type="button"
       class="usa-accordion__button display-flex flex-justify"
@@ -9,7 +9,7 @@
     >
       <div>Available Evaluators</div>
     </button>
-  </h2>
+  </h4>
 
   <div class="usa-accordion__content padding-left-0" id="<%= rand %>">
     <% if @submission.available_evaluators.any? %>
@@ -71,9 +71,9 @@
     <% end %>
     <div class="usa-alert usa-alert--info maxw-tablet">
       <div class="usa-alert__body">
-        <h2 class="usa-alert__heading">
+        <h3 class="usa-alert__heading">
           Need more evaluators?
-        </h2>
+        </h3>
         <p class="usa-alert__text font-body-2xs">
             <%= link_to "Manage your existing evaluation panel and invite additional evaluators.", phase_evaluators_path(@submission.phase), class: "margin-y-1"  %>
         </p>

--- a/app/views/submissions/_details_form.html.erb
+++ b/app/views/submissions/_details_form.html.erb
@@ -54,7 +54,7 @@
     </div>
     <%= form_with(model: @submission, url: submission_path(@submission), class: "maxw-mobile-lg") do |form| %>
         <div class="usa-form-group">
-            <%= form.label :comments, "Comments and notes:", class: "usa-label", for: "#{rand}-comments" %>
+            <%= form.label :comments, "Notes:", class: "usa-label", for: "#{rand}-comments" %>
             <%= form.text_area :comments, class: "usa-textarea", default: @submission.comments, id: "#{rand}-comments" %>
         </div>
         <button type="submit" name="commit" class="usa-button font-body-2xs text-no-wrap margin-y-2">

--- a/app/views/submissions/_submission_evaluation.html.erb
+++ b/app/views/submissions/_submission_evaluation.html.erb
@@ -1,4 +1,3 @@
-<h3>Submission Evaluation</h3>
 <% if @submission.phase.evaluation_form.nil? %>
   <%= render 'shared/alert_error', alert_heading: t('alerts.no_evaluation_form.heading'), alert_text: t('alerts.no_evaluation_form.text') %>
 <% else %>

--- a/app/views/submissions/_submission_evaluation.html.erb
+++ b/app/views/submissions/_submission_evaluation.html.erb
@@ -1,4 +1,4 @@
-<h2>Submission Evaluation</h2>
+<h3>Submission Evaluation</h3>
 <% if @submission.phase.evaluation_form.nil? %>
   <%= render 'shared/alert_error', alert_heading: t('alerts.no_evaluation_form.heading'), alert_text: t('alerts.no_evaluation_form.text') %>
 <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,7 @@ en:
       text: "An evaluator recused themselves from evaluating one or more of the challenge submissions. Please review the list of submissions below and unassign the evaluator from the submission(s)."
     recused_evaluator_submission:
       heading: "Recused Evaluator"
-      text: "This submission has a recused evaluator. Unassign recused evaluators"
+      text: "This submission has a recused evaluator. Unassign recused evaluators."
     assign_more_evaluator:
       heading: "Need to assign the evaluator to more submissions?"
       text: "You can assign as many evaluators as needed to each submission."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,7 +148,7 @@ en:
       text: "An evaluator recused themselves from evaluating one or more of the challenge submissions. Please review the list of submissions below and unassign the evaluator from the submission(s)."
     recused_evaluator_submission:
       heading: "Recused Evaluator"
-      text: "This submission has a recused evaluator. Please unassign a recused evaluator."
+      text: "This submission has a recused evaluator. Unassign recused evaluators"
     assign_more_evaluator:
       heading: "Need to assign the evaluator to more submissions?"
       text: "You can assign as many evaluators as needed to each submission."

--- a/spec/system/submission_details_spec.rb
+++ b/spec/system/submission_details_spec.rb
@@ -55,7 +55,7 @@ describe "A11y", :js do
 
     it "saves comments" do
       visit submission_path(submission)
-      fill_in "Comments and notes:", with: fake_comments
+      fill_in "Notes:", with: fake_comments
       click_on "Save"
       expect(page).to have_css("p.usa-alert__text", text: "Submission was updated successfully.")
       assert_text(fake_comments)
@@ -101,7 +101,7 @@ describe "A11y", :js do
       find_by_id('eligible-for-evaluation').click
       click_on('Save')
 
-      expect(page).to have_content("You currently do not have any evaluators assigned to this submission.")
+      expect(page).to have_content("This submission does not have any assigned evaluators. Please use the Available Evaluators section above to assign evaluators.")
 
       click_on('Assign')
       expect(page).to have_css("p.usa-alert__text", text: "Evaluator assigned successfully")


### PR DESCRIPTION
#402 
https://github.com/GSA/Challenge_platform/issues/402#issuecomment-2711867240
- [x] Only submission ID should be an H2, all headings below on the page, including submission information should be H3
- [x] Accordion headings should be H4
- [x] The alert message text should be left aligned (reduce left margin?)
- [x] Recused alert should be within Assigned Evaluators accordion
- [x] The icon in front of the recused evaluator name can be removed
- [x] When submission information is opened on a new tab, the Challenge title should be displayed as H1, and all other headings updated accordingly
- [x] Move submission title to the top of submission information