### PR TITLE
[388] Fix Evaluator Panel Error Messages and Form Clearing

### DIFF
--- a/app/javascript/controllers/form_validation_controller.js
+++ b/app/javascript/controllers/form_validation_controller.js
@@ -67,4 +67,44 @@ export default class extends Controller {
       errorElement.innerHTML = message;
     }
   }
+  
+  clearForm(e) {
+    e.preventDefault();
+    const form = e.target.closest('form');
+
+    form.reset();
+    
+    form.querySelectorAll('input[type="text"], input[type="email"]').forEach(input => {
+      input.value = '';
+    });
+    
+    this.clearAllErrors(form);
+  }
+  
+  clearAllErrors(form) {
+    const errorAlert = form.querySelector('.usa-alert--error');
+    if (errorAlert) {
+      errorAlert.remove();
+    }
+  
+    const formGroups = form.querySelectorAll('.usa-form-group');
+    formGroups.forEach(group => {
+      const input = group.querySelector('input, textarea, select');
+      if (input) {
+        input.className = input.className.replace(/usa-input--error/g, '');
+        
+        const label = this.findLabel(input, group);
+        if (label) {
+          label.className = label.className.replace(/usa-label--error/g, '');
+        }
+        
+        this.removeErrorClasses(input, label);
+  
+        const errorSpan = group.querySelector('[id$="_error"]');
+        if (errorSpan) {
+          errorSpan.textContent = '';
+        }
+      }
+    });
+  }
 }

--- a/app/models/evaluator_invitation.rb
+++ b/app/models/evaluator_invitation.rb
@@ -18,9 +18,8 @@ class EvaluatorInvitation < ApplicationRecord
   belongs_to :challenge
   belongs_to :phase
 
-  validates :first_name, presence: true
-  validates :last_name, presence: true
-  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validate :validate_full_name
+  validate :validate_email
   validates :last_invite_sent, presence: true
 
   validates :email, uniqueness: { scope: [:challenge_id, :phase_id] }
@@ -36,5 +35,19 @@ class EvaluatorInvitation < ApplicationRecord
 
   def full_name
     "#{first_name} #{last_name}".strip
+  end
+
+  private
+
+  def validate_full_name
+    return if first_name.present? && last_name.present?
+
+    errors.add(:full_name, I18n.t('evaluators.error.full_name'))
+  end
+
+  def validate_email
+    return if email.present? && email =~ URI::MailTo::EMAIL_REGEXP
+
+    errors.add(:email, I18n.t('evaluators.error.email_address'))
   end
 end

--- a/app/services/evaluator_management_service.rb
+++ b/app/services/evaluator_management_service.rb
@@ -51,11 +51,10 @@ class EvaluatorManagementService
       )
       { success: true }
     else
-      name_errors = temp_invitation.errors.messages.slice(:first_name, :last_name)
-      first_error_field, first_error_message = name_errors.first
+      full_name_error = temp_invitation.errors.messages.slice(:full_name)
       { success: false,
-        message: "#{first_error_field.to_s.humanize} #{first_error_message.first}",
-        errors: name_errors }
+        message: full_name_error[:full_name]&.first,
+        errors: full_name_error }
     end
   end
 

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -109,7 +109,7 @@
           <tbody>
             <% @existing_evaluators.each do |evaluator| %>
               <tr data-evaluator-id="<%= evaluator.id %>" data-evaluator-type="user">
-                <th scope="row" data-label="Name" class="text-top">
+                <th scope="row" data-label="Name">
                 <% if evaluator_available_for_assignment?(evaluator) %>
                   <%= link_to phase_evaluator_submission_assignments_path(@phase, evaluator_id: evaluator.id) do %>
                     <%= evaluator.full_name %>
@@ -118,10 +118,10 @@
                   <%= evaluator.full_name %>
                 <% end %>
                 </th>
-                <td data-label="Email Address" class="text-top"><%= evaluator.email %></td>
-                <td data-label="User Role" class="text-top"><%= evaluator.role.titleize %></td>
-                <td data-label="User Status" class="text-top"><%= user_status(evaluator) %></td>
-                <td data-label="# of Assigned Submissions" class="text-top">
+                <td data-label="Email Address"><%= evaluator.email %></td>
+                <td data-label="User Role"><%= evaluator.role.titleize %></td>
+                <td data-label="User Status"><%= user_status(evaluator) %></td>
+                <td data-label="# of Assigned Submissions">
                   <% submissions_count = assigned_submissions_count(evaluator, @challenge, @phase) %>
                   <% if submissions_count > 0 %>
                     <% if evaluator_available_for_assignment?(evaluator) %>
@@ -152,20 +152,20 @@
             <% end %>
             <% @challenge.evaluator_invitations.where(phase: @phase).each do |invitation| %>
               <tr data-evaluator-id="<%= invitation.id %>" data-evaluator-type="invitation">
-                <th scope="row" data-label="Evaluator name" class="text-top">
+                <th scope="row" data-label="Evaluator name">
                   <span class="text-ls-1 line-height-sans-4"><%= invitation.full_name %></span>
                 </th>
-                <td data-label="Email Address" class="text-top"><%= invitation.email %></td>
-                <td data-label="User Role" class="text-top">Evaluator</td>
-                <td data-label="User Status" class="text-top">
-                  <div class="display-flex flex-row flex-justify">
-                    <span>Invite Sent</span>
-                    <%= button_to resend_invite_phase_evaluator_path(@phase, invitation), method: :post, class: 'usa-button usa-button--unstyled margin-left-2', style: 'white-space: nowrap;', form: { class: 'display-inline' } do %>
+                <td data-label="Email Address"><%= invitation.email %></td>
+                <td data-label="User Role">Evaluator</td>
+                <td data-label="User Status">
+                  <div>
+                    <span>Invite Sent</span> -
+                    <%= button_to resend_invite_phase_evaluator_path(@phase, invitation), method: :post, class: 'usa-button usa-button--unstyled', form: {class: "display-inline-block"} do %>
                       <span class="text-primary">Resend</span>
                     <% end %>
                   </div>
                 </td>
-                <td data-label="# of Assigned Submissions" class="text-top">0 submissions</td>
+                <td data-label="# of Assigned Submissions">0 submissions</td>
                 <td data-label="">
                 <%= button_tag "Delete", type: 'button', class: 'usa-button usa-button--outline font-body-3xs', data: { 
                   action: "click->delete-evaluator-modal#open",

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -22,16 +22,11 @@
                 <%= pluralize(form.object.errors.count, "error") %> prohibited this evaluator from being added:
               </h3>
               <ul>
-                <% if form.object.errors[:first_name].present? || form.object.errors[:last_name].present? %>
+                <% if form.object.errors[:full_name].present? %>
                   <li><%= t('evaluators.error.full_name') %></li>
                 <% end %>
                 <% if form.object.errors[:email].present? %>
                   <li><%= t('evaluators.error.email_address') %></li>
-                <% end %>
-                <% form.object.errors.each do |error| %>
-                  <% unless [:first_name, :last_name, :email].include?(error.attribute) %>
-                    <li><%= error.full_message %></li>
-                  <% end %>
                 <% end %>
               </ul>
             </div>
@@ -41,12 +36,12 @@
 
       <div class="usa-form-group">
         <div class="display-flex flex-align-center text-bold">
-          <%= form.label :full_name, class: "usa-label font-sans-md #{label_error_class(form, [:first_name, :last_name])}" do %>
+          <%= form.label :full_name, class: "usa-label font-sans-md #{label_error_class(form, [:full_name])}" do %>
             <span class="text-bold">Full Name</span><span class="text-red">*</span>
           <% end %>
         </div>
         <%= form.text_field :full_name, 
-          class: "usa-input #{input_error_class(form, [:first_name, :last_name])}", 
+          class: "usa-input #{input_error_class(form, [:full_name])}",
           required: true,
           autocomplete: "name",
           style: "border: 1.5px solid #565c65;",
@@ -55,7 +50,7 @@
             "field-label": "full name"
           }
         %>
-        <%= inline_error(form, :last_name) %>
+        <%= inline_error(form, :full_name) %>
       </div>
 
       <div class="usa-form-group">
@@ -158,7 +153,7 @@
             <% @challenge.evaluator_invitations.where(phase: @phase).each do |invitation| %>
               <tr data-evaluator-id="<%= invitation.id %>" data-evaluator-type="invitation">
                 <th scope="row" data-label="Evaluator name" class="text-top">
-                  <span class="text-bold text-ls-1 line-height-sans-4"><%= "#{invitation.first_name} #{invitation.last_name}" %></span>
+                  <span class="text-ls-1 line-height-sans-4"><%= invitation.full_name %></span>
                 </th>
                 <td data-label="Email Address" class="text-top"><%= invitation.email %></td>
                 <td data-label="User Role" class="text-top">Evaluator</td>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -28,6 +28,11 @@
                 <% if form.object.errors[:email].present? %>
                   <li><%= t('evaluators.error.email_address') %></li>
                 <% end %>
+                <% form.object.errors.each do |error| %>
+                  <% unless [:full_name, :email].include?(error.attribute) %>
+                    <li><%= error.full_message %></li>
+                  <% end %>
+                <% end %>
               </ul>
             </div>
           </div>

--- a/app/views/evaluators/index.html.erb
+++ b/app/views/evaluators/index.html.erb
@@ -22,8 +22,16 @@
                 <%= pluralize(form.object.errors.count, "error") %> prohibited this evaluator from being added:
               </h3>
               <ul>
+                <% if form.object.errors[:first_name].present? || form.object.errors[:last_name].present? %>
+                  <li><%= t('evaluators.error.full_name') %></li>
+                <% end %>
+                <% if form.object.errors[:email].present? %>
+                  <li><%= t('evaluators.error.email_address') %></li>
+                <% end %>
                 <% form.object.errors.each do |error| %>
-                  <li><%= error.full_message %></li>
+                  <% unless [:first_name, :last_name, :email].include?(error.attribute) %>
+                    <li><%= error.full_message %></li>
+                  <% end %>
                 <% end %>
               </ul>
             </div>
@@ -43,9 +51,9 @@
           autocomplete: "name",
           style: "border: 1.5px solid #565c65;",
           data: {
-            action: "form-validation#validatePresence focusout->form-validation#validatePresence"
-          },
-          value: form.object.full_name
+            action: "form-validation#validatePresence focusout->form-validation#validatePresence",
+            "field-label": "full name"
+          }
         %>
         <%= inline_error(form, :last_name) %>
       </div>
@@ -62,7 +70,8 @@
           autocomplete: "email",
           style: "border: 1.5px solid #565c65;",
           data: {
-            action: "form-validation#validatePresence focusout->form-validation#validatePresence"
+            action: "form-validation#validatePresence focusout->form-validation#validatePresence",
+            "field-label": "email address"
           }
         %>
         <%= inline_error(form, :email) %>        
@@ -73,7 +82,7 @@
         Add Evaluator
       <% end %>
 
-      <input type="reset" value="Cancel" class="usa-button usa-button--unstyled width-auto"/>
+      <input type="button" value="Cancel" class="usa-button usa-button--unstyled width-auto" data-action="click->form-validation#clearForm"/>
     <% end %>
     <% if @evaluator_invitations.empty? && @existing_evaluators.empty? %>
       <div class="usa-alert usa-alert--warning maxw-tablet margin-bottom-5">
@@ -152,7 +161,7 @@
                   </div>
                 </td>
                 <td data-label="# of Assigned Submissions" class="text-top">0 submissions</td>
-                <td data-label="" class="text-right">
+                <td data-label="">
                 <%= button_tag "Delete", type: 'button', class: 'usa-button usa-button--outline font-body-3xs', data: { 
                   action: "click->delete-evaluator-modal#open",
                   evaluator_id: invitation.id, 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,8 +76,8 @@ en:
       success: "Invitation resent successfully."
       failure: "Failed to resend invitation."
     error:
-      full_name: "Please provide evaluator's full name"
-      email_address: "Please provide evaluator's valid email address"
+      full_name: "Please provide full name"
+      email_address: "Please provide valid email address"
   evaluation_criteria_form_title_placeholder: "Add criteria title here"
   evaluator_submission_assignments:
     empty_state: "There currently are no assigned submissions to this evaluator. Please assign submissions to this evaluator to view."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,8 +76,8 @@ en:
       success: "Invitation resent successfully."
       failure: "Failed to resend invitation."
     error:
-      full_name: "Please provide full name"
-      email_address: "Please provide valid email address"
+      full_name: "Please provide evaluator's full name"
+      email_address: "Please provide evaluator's valid email address"
   evaluation_criteria_form_title_placeholder: "Add criteria title here"
   evaluator_submission_assignments:
     empty_state: "There currently are no assigned submissions to this evaluator. Please assign submissions to this evaluator to view."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,10 @@ en:
       success: "Evaluator created and added to challenge phase successfully."   
     resend_invite:
       success: "Invitation resent successfully."
-      failure: "Failed to resend invitation."      
+      failure: "Failed to resend invitation."
+    error:
+      full_name: "Please provide evaluator's full name"
+      email_address: "Please provide evaluator's valid email address"
   evaluation_criteria_form_title_placeholder: "Add criteria title here"
   evaluator_submission_assignments:
     empty_state: "There currently are no assigned submissions to this evaluator. Please assign submissions to this evaluator to view."

--- a/spec/models/evaluator_invitation_spec.rb
+++ b/spec/models/evaluator_invitation_spec.rb
@@ -52,18 +52,18 @@ RSpec.describe EvaluatorInvitation, type: :model do
   it "requires a first name" do
     invitation = build(:evaluator_invitation, first_name: nil)
     expect(invitation).not_to be_valid
-    expect(invitation.errors[:first_name]).to include("can't be blank")
+    expect(invitation.errors[:full_name]).to include("Please provide evaluator's full name")
   end
 
   it "requires a last name" do
     invitation = build(:evaluator_invitation, last_name: nil)
     expect(invitation).not_to be_valid
-    expect(invitation.errors[:last_name]).to include("can't be blank")
+    expect(invitation.errors[:full_name]).to include("Please provide evaluator's full name")
   end
 
   it "requires a valid email" do
     invitation = build(:evaluator_invitation, email: "invalid_email")
     expect(invitation).not_to be_valid
-    expect(invitation.errors[:email]).to include("is invalid")
+    expect(invitation.errors[:email]).to include("Please provide evaluator's valid email address")
   end
 end

--- a/spec/services/evaluator_management_service_spec.rb
+++ b/spec/services/evaluator_management_service_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe EvaluatorManagementService do
       it 'requires full name when adding an existing user' do
         result = service.process_evaluator_invitation(evaluator.email, { email: evaluator.email, full_name: 'Santos' })
         expect(result[:success]).to be false
-        expect(result[:message]).to eq("Last name can't be blank")
+        expect(result[:message]).to eq("Please provide evaluator's full name")
       end
 
       it 'updates user name when adding as evaluator' do


### PR DESCRIPTION
Linked ticket: #388 

Address these AC failures/suggestions:
- [x] Update error messages in error alert and error message by the form field to: "Please provide evaluator's full name" and "Please provide evaluator's valid email address"
- [x] Should clicking on cancel clear out the form fields and also error messages (for example if the user changed their mind about adding a new evaluator, they should be able to clear out the form and not have prior error messages persist)?
- [x] Delete buttons should align in a column

Note: generateErrorMessage doesn't validate full_name as expected because first_name and last_name are the expected attributes on the model and not full_name. The inline_error message has to include last_name. 

***********

<img width="1393" alt="Screenshot 2025-03-11 at 7 13 46 PM" src="https://github.com/user-attachments/assets/36a43387-db73-43fc-9af4-02036a6e768d" />

<img width="652" alt="Screenshot 2025-03-11 at 7 22 18 PM" src="https://github.com/user-attachments/assets/6a3c32e1-5a2b-49c9-9675-1cd22b862bec" />

<img width="611" alt="Screenshot 2025-03-11 at 7 22 34 PM" src="https://github.com/user-attachments/assets/72449e57-dd44-45f3-a6f7-5f86a32a8aba" />

![388_clear_errors_on_cancel](https://github.com/user-attachments/assets/322d3576-2d84-4155-9163-934da1a9364e)
