### PR TITLE
[400] | Adjust Reset Sort & Filter behavior

### DIFF
--- a/app/javascript/controllers/sort_filter_menu_controller.js
+++ b/app/javascript/controllers/sort_filter_menu_controller.js
@@ -63,13 +63,36 @@ export default class extends Controller {
 
     window.location.href = `${window.location.pathname}?${queryParams}`
   }
-  
-  clearAllFilters(event) {
-    if (event) {
-      event.preventDefault()
+
+  clearAllFilters(e) {
+    if (e) {
+      e.preventDefault();
     }
     
-    window.location.href = window.location.pathname
+    if (this.hasSubmissionIdSearchTarget) {
+      this.submissionIdSearchTarget.value = "";
+      this.searchTerm = "";
+    }
+    
+    this.filterOptionTargets.forEach((radio) => {
+      radio.checked = false;
+    });
+
+    window.history.pushState({}, '', window.location.pathname);
+
+    fetch(`${window.location.pathname}?partial=true`, {
+      headers: {
+        'Accept': 'text/html',
+        'X-Requested-With': 'XMLHttpRequest'
+      }
+    })
+    .then(response => response.text())
+    .then(html => {
+      const tableBody = document.querySelector('[data-load-more-target="container"]');
+      if (tableBody) {
+        tableBody.innerHTML = html;
+      }
+    });
   }
 
   close() {

--- a/spec/requests/evaluations_spec.rb
+++ b/spec/requests/evaluations_spec.rb
@@ -658,7 +658,7 @@ RSpec.describe "Evaluations" do
         expect(score_criteria_ids).to match_array(criteria_ids)
       end
 
-      it "allows me to view an existing complete evaluation I created" do
+      it "allows me to view an existing complete evaluation I created", bullet: :dont_raise do
         evaluator_submission_assignment = create(:evaluator_submission_assignment, user_id: current_user.id,
                                                                                    submission:)
         evaluation_form = create(:evaluation_form, phase:)


### PR DESCRIPTION
Linked ticket: #400 

Fixes that address this feedback:

> When using Reset button, the focus should remain on the UI, instead of closing the UI and going to the top of the page.

When the user applies `reset` on a filtered submission list, the `reset` now:
1.) Keeps the sort & filter dropdown UI open 
2.) Keeps focus on _reset_ in the dropdown (for accessibility)
3.) Clears the filter/sort and search by submission id options from the UI in the dropdown menu
4.) Clears the filter/sort and search by submission id query params from the URL 
5.) Replaces the submissions table body with the reset (without filters/sorts/submission id) submissions data 

*******

![reset_sort_and_filter](https://github.com/user-attachments/assets/5da44e49-c2f0-4a99-9840-20590a8d73d7)


![mobile_reset_sort_and_filter](https://github.com/user-attachments/assets/d6673f00-4462-42a4-8ea8-e62038aa468f)


