### PR TITLE
Use assigned_submissions_count function

### DIFF
--- a/app/views/submissions/_available_evaluators.html.erb
+++ b/app/views/submissions/_available_evaluators.html.erb
@@ -33,7 +33,7 @@
               </th>
               <td data-label="# of Assigned Submissions" class="text-top">
                 <span class="margin-x-1">
-                  <%= evaluator.assigned_submissions.count %> submissions
+                  <%= assigned_submissions_count(evaluator, @submission.challenge, @submission.phase) %> submissions
                 </span>
               </td>
               <td data-label="Actions">


### PR DESCRIPTION
The Assigned Evaluators table on the CM submission detail page was incorrectly showing the total number of assignments for the user. It is now scoped to the current challenge phase.