### PR TITLE
fix pages_spec for local dev

### DIFF
--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,45 +1,49 @@
 require "rails_helper"
 
 RSpec.describe "PagesController" do
-  it "get root renders successfully" do
-    stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/").
-      to_return(status: 200, body: "", headers: {})
+  context "#root" do
+    it "renders successfully" do
+      stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/").
+        to_return(status: 200, body: "", headers: {})
 
-    get "/"
-    expect(response).to be_ok
-  end
-
-  it "replaces full paths from body to assets so they proxy too" do
-    body = "BEGIN_#{PagesController::HOST}#{PagesController::BASE_URL}_END"
-    stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/").
-      to_return(status: 200, body:, headers: {})
-
-    get "/"
-    expected_body = if PagesController::BASE_URL == "/"
-      "BEGIN_//_END"
-    else
-      "BEGIN_/_END"
+      get "/"
+      expect(response).to be_ok
     end
-    expect(response.body).to eq(expected_body)
+
+    it "converts full paths in the response body with local paths so they proxy too" do
+      body = "BEGIN_#{PagesController::HOST}#{PagesController::BASE_URL}_END"
+      stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/").
+        to_return(status: 200, body:, headers: {})
+
+      get "/"
+      expected_body = if PagesController::BASE_URL == "/"
+        "BEGIN_//_END"
+      else
+        "BEGIN_/_END"
+      end
+      expect(response.body).to eq(expected_body)
+    end
   end
 
-  it "works for minified js assets" do
-    stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/assets/uswds.min.js").
-      to_return(status: 200, body: "", headers: {})
+  context "#assets" do
+    it "works for minified js assets" do
+      stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/assets/uswds.min.js").
+        to_return(status: 200, body: "", headers: {})
 
-    get "/assets/uswds.min.js"
-    expect(response).to be_ok
+      get "/assets/uswds.min.js"
+      expect(response).to be_ok
+    end
+
+    it "works for image assets" do
+      stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/assets/logo.svg").
+        to_return(status: 200, body: "", headers: {})
+
+      get "/assets/logo.svg"
+      expect(response).to be_ok
+    end
   end
 
-  it "works for image assets" do
-    stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/assets/logo.svg").
-      to_return(status: 200, body: "", headers: {})
-
-    get "/assets/logo.svg"
-    expect(response).to be_ok
-  end
-
-  it "404s to the root path" do
+  it "404 redirects to the root path" do
     stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/not_found/").
       to_return(status: 404, body: "", headers: {})
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -9,12 +9,18 @@ RSpec.describe "PagesController" do
     expect(response).to be_ok
   end
 
-  it "removes full paths to assets so they proxy too" do
+  it "replaces full paths from body to assets so they proxy too" do
+    body = "BEGIN_#{PagesController::HOST}#{PagesController::BASE_URL}_END"
     stub_request(:get, "#{PagesController::HOST}#{PagesController::BASE_URL}/").
-      to_return(status: 200, body: PagesController::HOST + PagesController::BASE_URL, headers: {})
+      to_return(status: 200, body:, headers: {})
 
     get "/"
-    expect(response.body).to eq("/")
+    expected_body = if PagesController::BASE_URL == "/"
+      "BEGIN_//_END"
+    else
+      "BEGIN_/_END"
+    end
+    expect(response.body).to eq(expected_body)
   end
 
   it "works for minified js assets" do


### PR DESCRIPTION
There's an issue with the specs if you have use `localhost` setup for the `PAGES_*` env. This fixes the spec to allow specs to pass locally no matter how PAGES are configured.